### PR TITLE
Upgrade postgres 18

### DIFF
--- a/lib/postgres/docker-compose.yml
+++ b/lib/postgres/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres-db:
-    image: postgres:16
+    image: postgres:18
     ports:
       - "5433:5432"
     environment:
@@ -12,7 +12,7 @@ services:
     extra_hosts:
       - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     logging:
       driver: "fluentd"
       options:


### PR DESCRIPTION
## What's new
- Upgrade postgres 18

### How to test
- Download the `clinical_backup_18.dump`, rename to `clinical_backup.dump` 
- Place it in `candig-api/db` folder
- (If you are previously set python to 3.14 and pip 25.3, it is fine)
- Rebuild the stack (no test-integration)