### PR TITLE
Fixup candig-api not getting added to federation

### DIFF
--- a/lib/federation/initialize.py
+++ b/lib/federation/initialize.py
@@ -17,8 +17,9 @@ def get_default_services():
         service = {
             'id': s
         }
-        service_port = f"{s.upper()}_PORT"
-        service_version = f"{s.upper()}_VERSION"
+        service_safename = s.upper().replace("-", "_")
+        service_port = f"{service_safename}_PORT"
+        service_version = f"{service_safename}_VERSION"
         service['url'] = f"http://{get_env_value('CANDIG_DOMAIN')}:{get_env_value(service_port)}"
         service['version'] = get_env_value(service_version)
         services.append(service)


### PR DESCRIPTION
Include a fixup how federation handles service names with dashes in them (candig-api)