### PR TITLE
Add small ingestable OMOP file

### DIFF
--- a/etc/tests/integration/omop-sample.json
+++ b/etc/tests/integration/omop-sample.json
@@ -1,0 +1,10029 @@
+{
+	"datasets": [
+		{
+			"dataset": {
+				"id": "SITE_PM2C~SYNTH_01",
+				"linked_records": [
+					{
+						"person": {
+							
+								"person_source_value": "SITE_PM2C~SYNTH_01~DONOR_0001",
+								"gender_concept_id": "4255047",
+								"year_of_birth": "1948",
+								"month_of_birth": "1",
+								"day_of_birth": "19",
+								"race_concept_id": "4255047",
+								"ethnicity_concept_id": "4255047"
+							
+						},
+						"linked_records": [
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "DONOR_0001~OMOP_Gender_Identity_Observation",
+									"observation_concept_id": "37171290",
+									"value_as_concept_id": "37171288",
+									"value_source_value": "Non-binary"
+								}
+							},
+							{
+								"death": {
+									"death_type_concept_id": "32879",
+									"death_date": "1800-01-01"
+								}
+							},
+							{
+								"condition_occurrence": {
+									"condition_type_concept_id": "32879",
+									"condition_occurrence_id": "DIAG_0001~OMOP_Primary_Dx_Condition",
+									"condition_concept_id": "45532967",
+									"condition_source_value": "D05",
+									"condition_start_date": "2000-01-01",
+									"condition_status_concept_id": "32902"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "DIAG_0001~OMOP_Primary_Dx_Episode",
+									"episode_concept_id": "32528",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "45532967",
+									"episode_number": "1",
+									"episode_start_date": "2000-01-01",
+									"episode_end_date": "2000-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0001~OMOP_Primary_Dx_Episode",
+									"event_id": "DIAG_0001~OMOP_Primary_Dx_Condition",
+									"episode_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0001~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0001~OMOP_Primary_Dx_Initial_Diagnosis_Measurement",
+									"measurement_concept_id": "734306",
+									"value_as_concept_id": "4190930",
+									"value_source_value": "Histology of a metastasis"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-01",
+									"observation_id": "DIAG_0001~OMOP_Primary_Dx_Site_Observation",
+									"observation_concept_id": "3011717",
+									"value_as_concept_id": "44497844",
+									"value_source_value": "Breast",
+									"observation_event_id": "DIAG_0001~OMOP_Primary_Dx_Condition",
+									"obs_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0001~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0001~OMOP_Clinical_Stage_Measurement",
+									"measurement_concept_id": "1243639",
+									"measurement_source_value": "Lugano staging system",
+									"value_as_concept_id": "45876317",
+									"value_source_value": "Stage IB"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0001~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0001~OMOP_Pathological_Stage_Measurement",
+									"measurement_concept_id": "607126",
+									"measurement_source_value": "Revised International staging system (R-ISS)",
+									"value_as_concept_id": "0",
+									"value_source_value": "Stage IVAE"
+								}
+							},
+							{
+								"specimen": {
+									"specimen_type_concept_id": "32879",
+									"specimen_id": "SPECIMEN_0001~OMOP_Specimen",
+									"specimen_concept_id": "4002890",
+									"specimen_date": "2000-01-21",
+									"anatomic_site_concept_id": "44498108",
+									"anatomic_site_source_value": "C16.5"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-21",
+									"observation_id": "SPECIMEN_0001~OMOP_Specimen_Tumour_Morphology_Observation",
+									"observation_concept_id": "36716952",
+									"observation_event_id": "SPECIMEN_0001~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "44498374",
+									"value_source_value": "8854/3"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-21",
+									"observation_id": "SPECIMEN_0001~OMOP_Specimen_Tumour_Grade_Observation",
+									"observation_concept_id": "4160340",
+									"observation_event_id": "SPECIMEN_0001~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "37164077",
+									"value_source_value": "G3",
+									"qualifier_concept_id": "4161055",
+									"qualifier_source_value": "Nuclear grading system for DCIS"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-21",
+									"observation_id": "SPECIMEN_0001~OMOP_Specimen_Laterality_Observation",
+									"observation_concept_id": "4298494",
+									"observation_event_id": "SPECIMEN_0001~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4080761",
+									"value_source_value": "Right"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-21",
+									"observation_id": "SPECIMEN_0001~OMOP_Specimen_Storage_Method_Observation",
+									"observation_concept_id": "37169821",
+									"observation_event_id": "SPECIMEN_0001~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "0",
+									"value_source_value": "OCT embedded"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0001~OMOP_Primary_Dx_Episode",
+									"event_id": "SPECIMEN_0001~OMOP_Specimen",
+									"episode_event_field_concept_id": "1147049"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0001~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-06-10",
+									"episode_number": "4188539"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0001~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Other|Radiation therapy|Surgery|Systemic therapy",
+									"procedure_date": "2000-06-10"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0001~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0001~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-10",
+									"observation_id": "TREATMENT_0001~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0001~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4234571",
+									"value_source_value": "Screening"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-10",
+									"observation_id": "TREATMENT_0001~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "4255047",
+									"observation_event_id": "TREATMENT_0001~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "Blazer score"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "2000-08-19",
+									"episode_end_date": "2000-11-15"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0001~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "2000-08-19",
+									"quantity": 3
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "2000-08-19",
+									"drug_exposure_end_date": "2000-11-15",
+									"quantity": 78.4
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "2000-08-19",
+									"drug_exposure_end_date": "2000-11-15",
+									"quantity": 26.3
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4273629",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0001~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4273629",
+									"procedure_source_value": "Chemotherapy",
+									"procedure_date": "1800-01-01",
+									"quantity": 1
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|36314|Paclitaxel",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"dose_unit_source_value": "mg/m2",
+									"quantity": 73.2
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|36314|Paclitaxel",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"dose_unit_source_value": "mg/m2",
+									"quantity": 28.8
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0001~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0001~OMOP_Surgery_Episode",
+									"episode_concept_id": "32939",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4096783",
+									"episode_start_date": "2000-06-10"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0001~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0001~OMOP_Surgery_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0001~OMOP_Surgery_Procedure",
+									"procedure_concept_id": "4096783",
+									"procedure_source_value": "SNOMED|26294005|Radical prostatectomy",
+									"procedure_date": "2000-06-10"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0001~OMOP_Surgery_Episode",
+									"event_id": "TREATMENT_0001~OMOP_Surgery_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-06-10",
+									"measurement_id": "TREATMENT_0001~OMOP_Surgery_Episode_Tumour_Length_Measurement",
+									"measurement_concept_id": "4156562",
+									"measurement_event_id": "TREATMENT_0001~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 8.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-06-10",
+									"measurement_id": "TREATMENT_0001~OMOP_Surgery_Episode_Tumour_Width_Measurement",
+									"measurement_concept_id": "4156563",
+									"measurement_event_id": "TREATMENT_0001~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 6.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-10",
+									"observation_id": "TREATMENT_0001~OMOP_Surgery_Episode_Surgery_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0001~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "C16.8"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-10",
+									"observation_id": "TREATMENT_0001~OMOP_Surgery_Episode_Surgery_Tumour_Focality_Observation",
+									"observation_concept_id": "4244984",
+									"observation_event_id": "TREATMENT_0001~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4181140",
+									"value_source_value": "Multifocal"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-10",
+									"observation_id": "TREATMENT_0001~OMOP_Surgery_Episode_Residual_Tumour_Classification_Observation",
+									"observation_concept_id": "4077124",
+									"observation_event_id": "TREATMENT_0001~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "36311187",
+									"value_source_value": "R1"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-10",
+									"observation_id": "TREATMENT_0001~OMOP_Surgery_Episode_Lymphovascular_Invasion_Observation",
+									"observation_concept_id": "1074673",
+									"observation_event_id": "TREATMENT_0001~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4184072",
+									"value_source_value": "Venous (large vessel) invasion only"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-10",
+									"observation_id": "TREATMENT_0001~OMOP_Surgery_Episode_Perineural_Invasion_Observation",
+									"observation_concept_id": "4161179",
+									"observation_event_id": "TREATMENT_0001~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "607928",
+									"value_source_value": "Cannot be assessed"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-10",
+									"observation_id": "TREATMENT_0001~OMOP_Surgery_Episode_Margin_Positive_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0001~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Common bile duct margin",
+									"qualifier_concept_id": "9191"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-10",
+									"observation_id": "TREATMENT_0001~OMOP_Surgery_Episode_Margin_Unassessible_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0001~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Not available",
+									"qualifier_concept_id": "4183475"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0002~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-06-16",
+									"episode_end_date": "2001-02-25",
+									"episode_number": "4188540"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0002~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Surgery|Stem cell transplant...",
+									"procedure_date": "2000-06-16",
+									"modifier_concept_id": "4191710",
+									"modifier_source_value": "Treatment stopped due to acute toxicity"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0002~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0002~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-16",
+									"observation_id": "TREATMENT_0002~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0002~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4161275",
+									"value_source_value": "Supportive"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-16",
+									"observation_id": "TREATMENT_0002~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36308003",
+									"value_source_value": "Progressive disease",
+									"observation_event_id": "TREATMENT_0002~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "AML Response Criteria"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0002~OMOP_Radiation_Episode",
+									"episode_concept_id": "32940",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4255047",
+									"episode_start_date": "2000-06-16"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0002~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0002~OMOP_Radiation_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0002~OMOP_Radiation_Procedure",
+									"procedure_concept_id": "4255047",
+									"procedure_date": "2000-06-16"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0002~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0002~OMOP_Radiation_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-06-16",
+									"measurement_id": "TREATMENT_0002~OMOP_Radiation_Episode_Total_Dose_Given_Measurement",
+									"measurement_concept_id": "40483776",
+									"measurement_event_id": "TREATMENT_0002~OMOP_Radiation_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 91,
+									"unit_concept_id": "4037797"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-06-16",
+									"measurement_id": "TREATMENT_0002~OMOP_Radiation_Episode_Total_Fractions_Given_Measurement",
+									"measurement_concept_id": "4037631",
+									"measurement_event_id": "TREATMENT_0002~OMOP_Radiation_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 24
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-16",
+									"observation_id": "TREATMENT_0002~OMOP_Radiation_Episode_Radiated_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0002~OMOP_Radiation_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4192373",
+									"value_source_value": "FINGER (INCLUDING THUMBS)"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0002~OMOP_Radiation_Boost_Procedure",
+									"procedure_concept_id": "40482853",
+									"procedure_date": "2000-06-16",
+									"modifier_concept_id": "4188540",
+									"modifier_source_value": "No"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0002~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0002~OMOP_Radiation_Boost_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4273629",
+									"episode_start_date": "2001-01-15",
+									"episode_end_date": "2001-02-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0002~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4273629",
+									"procedure_source_value": "Chemotherapy",
+									"procedure_date": "2001-01-15",
+									"quantity": 3
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C1282|Carboplatin",
+									"drug_exposure_start_date": "2001-01-15",
+									"drug_exposure_end_date": "2001-02-01",
+									"dose_unit_source_value": "IU/m2",
+									"quantity": 65.7
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C1282|Carboplatin",
+									"drug_exposure_start_date": "2001-01-15",
+									"drug_exposure_end_date": "2001-02-01",
+									"dose_unit_source_value": "IU/m2",
+									"quantity": 41.6
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0002~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "1800-01-01",
+									"quantity": 7
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "1594034",
+									"drug_source_value": "RxNorm|1919503|Durvalumab",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"dose_unit_source_value": "IU/kg",
+									"quantity": 70.5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "1594034",
+									"drug_source_value": "RxNorm|1919503|Durvalumab",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"dose_unit_source_value": "IU/kg",
+									"quantity": 28.3
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0002~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1950-08-12",
+									"measurement_id": "DONOR_0001 + $.donors[0].biomarkers[0]~OMOP_PSA_Biomarker_Measurement",
+									"measurement_concept_id": "4272032",
+									"value_as_number": 99,
+									"unit_concept_id": "4120724"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1950-08-12",
+									"measurement_id": "DONOR_0001 + $.donors[0].biomarkers[0]~OMOP_CA125_Biomarker_Measurement",
+									"measurement_concept_id": "4197913",
+									"value_as_number": 82,
+									"unit_concept_id": "4118305"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1950-08-12",
+									"measurement_id": "DONOR_0001 + $.donors[0].biomarkers[0]~OMOP_CEA_Biomarker_Measurement",
+									"measurement_concept_id": "4244721",
+									"value_as_number": 22,
+									"unit_concept_id": "4120724"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1950-08-12",
+									"measurement_id": "DONOR_0001 + $.donors[0].biomarkers[0]~OMOP_Estrogen_Receptor_Biomarker_Measurement",
+									"measurement_concept_id": "4307360",
+									"value_as_concept_id": "9191",
+									"value_as_number": 61.36,
+									"unit_concept_id": "4041099"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1950-08-12",
+									"measurement_id": "DONOR_0001 + $.donors[0].biomarkers[0]~OMOP_HER2_IHC_Status_Biomarker_Measurement",
+									"measurement_concept_id": "35918264",
+									"value_as_concept_id": "607928"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1950-08-12",
+									"measurement_id": "DONOR_0001 + $.donors[0].biomarkers[0]~OMOP_HER2_ISH_Status_Biomarker_Measurement",
+									"measurement_concept_id": "35918706",
+									"value_as_concept_id": "9189"
+								}
+							}
+						]
+					},
+					{
+						"person": {
+							
+								"person_source_value": "SITE_PM2C~SYNTH_01~DONOR_0002",
+								"gender_concept_id": "8507",
+								"gender_source_value": "Male",
+								"year_of_birth": "1953",
+								"month_of_birth": "3",
+								"day_of_birth": "4",
+								"race_concept_id": "4255047",
+								"ethnicity_concept_id": "4255047"
+							
+						},
+						"linked_records": [
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "DONOR_0002~OMOP_Gender_Identity_Observation",
+									"observation_concept_id": "37171290",
+									"value_as_concept_id": "765761",
+									"value_source_value": "Woman"
+								}
+							},
+							{
+								"death": {
+									"death_type_concept_id": "32879",
+									"death_date": "1800-01-01"
+								}
+							},
+							{
+								"condition_occurrence": {
+									"condition_type_concept_id": "32879",
+									"condition_occurrence_id": "DIAG_0002~OMOP_Primary_Dx_Condition",
+									"condition_concept_id": "45537814",
+									"condition_source_value": "C45",
+									"condition_start_date": "2000-01-01",
+									"condition_status_concept_id": "32902"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "DIAG_0002~OMOP_Primary_Dx_Episode",
+									"episode_concept_id": "32528",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "45537814",
+									"episode_number": "1",
+									"episode_start_date": "2000-01-01",
+									"episode_end_date": "2000-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0002~OMOP_Primary_Dx_Episode",
+									"event_id": "DIAG_0002~OMOP_Primary_Dx_Condition",
+									"episode_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0002~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0002~OMOP_Primary_Dx_Initial_Diagnosis_Measurement",
+									"measurement_concept_id": "734306"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-01",
+									"observation_id": "DIAG_0002~OMOP_Primary_Dx_Site_Observation",
+									"observation_concept_id": "3011717",
+									"value_as_concept_id": "44498181",
+									"value_source_value": "Bronchus and lung",
+									"observation_event_id": "DIAG_0002~OMOP_Primary_Dx_Condition",
+									"obs_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0002~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0002~OMOP_Clinical_Stage_Measurement",
+									"measurement_concept_id": "4110410",
+									"measurement_source_value": "International Neuroblastoma...",
+									"value_as_concept_id": "45881605",
+									"value_source_value": "Stage 0a"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0002~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0002~OMOP_Pathological_Stage_Measurement",
+									"measurement_concept_id": "607126",
+									"measurement_source_value": "Revised International staging system (R-ISS)",
+									"value_as_concept_id": "0",
+									"value_source_value": "Stage B"
+								}
+							},
+							{
+								"specimen": {
+									"specimen_type_concept_id": "32879",
+									"specimen_id": "SPECIMEN_0002~OMOP_Specimen",
+									"specimen_concept_id": "4002890",
+									"specimen_date": "1800-01-01",
+									"anatomic_site_concept_id": "44498019",
+									"anatomic_site_source_value": "C00.5"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "SPECIMEN_0002~OMOP_Specimen_Tumour_Morphology_Observation",
+									"observation_concept_id": "36716952",
+									"observation_event_id": "SPECIMEN_0002~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "0",
+									"value_source_value": "9269/3"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "SPECIMEN_0002~OMOP_Specimen_Tumour_Grade_Observation",
+									"observation_concept_id": "4160340",
+									"observation_event_id": "SPECIMEN_0002~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "40459835",
+									"value_source_value": "Grade IV"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "SPECIMEN_0002~OMOP_Specimen_Laterality_Observation",
+									"observation_concept_id": "4298494",
+									"observation_event_id": "SPECIMEN_0002~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4080761",
+									"value_source_value": "Right"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "SPECIMEN_0002~OMOP_Specimen_Processing_Technique_Observation",
+									"observation_concept_id": "4154128",
+									"observation_event_id": "SPECIMEN_0002~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4338536",
+									"value_source_value": "Cryopreservation - other"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "SPECIMEN_0002~OMOP_Specimen_Storage_Method_Observation",
+									"observation_concept_id": "37169821",
+									"observation_event_id": "SPECIMEN_0002~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "0",
+									"value_source_value": "Paraffin block"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0002~OMOP_Primary_Dx_Episode",
+									"event_id": "SPECIMEN_0002~OMOP_Specimen",
+									"episode_event_field_concept_id": "1147049"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0003~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-05-13",
+									"episode_end_date": "2000-10-01",
+									"episode_number": "4188540"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0003~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Surgery|Systemic therapy",
+									"procedure_date": "2000-05-13",
+									"modifier_concept_id": "0",
+									"modifier_source_value": "Treatment ongoing"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0003~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0003~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-13",
+									"observation_id": "TREATMENT_0003~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36309727",
+									"value_source_value": "Complete remission with...",
+									"observation_event_id": "TREATMENT_0003~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "Response Assessment in Neuro-Oncology (RANO)"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "2000-06-28",
+									"episode_end_date": "2000-08-31"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0003~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "2000-06-28",
+									"quantity": 5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|469690927|Atezolizumab",
+									"drug_exposure_start_date": "2000-06-28",
+									"drug_exposure_end_date": "2000-08-31",
+									"dose_unit_source_value": "Not available",
+									"quantity": 95.5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|469690927|Atezolizumab",
+									"drug_exposure_start_date": "2000-06-28",
+									"drug_exposure_end_date": "2000-08-31",
+									"dose_unit_source_value": "Not available"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "2000-09-30",
+									"episode_end_date": "2000-09-30"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0003~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "2000-09-30",
+									"quantity": 1
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "2000-09-30",
+									"drug_exposure_end_date": "2000-09-30",
+									"quantity": 92.9
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "2000-09-30",
+									"drug_exposure_end_date": "2000-09-30",
+									"quantity": 30.1
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0003~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0003~OMOP_Surgery_Episode",
+									"episode_concept_id": "32939",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-05-13"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0003~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0003~OMOP_Surgery_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0003~OMOP_Surgery_Procedure",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "NCIt|C185240|Total gastrectomy",
+									"procedure_date": "2000-05-13"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0003~OMOP_Surgery_Episode",
+									"event_id": "TREATMENT_0003~OMOP_Surgery_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-05-13",
+									"measurement_id": "TREATMENT_0003~OMOP_Surgery_Episode_Tumour_Length_Measurement",
+									"measurement_concept_id": "4156562",
+									"measurement_event_id": "TREATMENT_0003~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 3.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-05-13",
+									"measurement_id": "TREATMENT_0003~OMOP_Surgery_Episode_Tumour_Width_Measurement",
+									"measurement_concept_id": "4156563",
+									"measurement_event_id": "TREATMENT_0003~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 9.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-05-13",
+									"measurement_id": "TREATMENT_0003~OMOP_Surgery_Episode_Greatest_Tumour_Dimension_Measurement",
+									"measurement_concept_id": "4154259",
+									"measurement_event_id": "TREATMENT_0003~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 10.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-13",
+									"observation_id": "TREATMENT_0003~OMOP_Surgery_Episode_Surgery_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0003~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "C41.9"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-13",
+									"observation_id": "TREATMENT_0003~OMOP_Surgery_Episode_Surgery_Tumour_Focality_Observation",
+									"observation_concept_id": "4244984",
+									"observation_event_id": "TREATMENT_0003~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4126041",
+									"value_source_value": "Unifocal"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-13",
+									"observation_id": "TREATMENT_0003~OMOP_Surgery_Episode_Surgery_Specimen_Source_Observation",
+									"observation_concept_id": "45773156",
+									"observation_event_id": "TREATMENT_0003~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4312326",
+									"value_source_value": "Primary"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-13",
+									"observation_id": "TREATMENT_0003~OMOP_Surgery_Episode_Residual_Tumour_Classification_Observation",
+									"observation_concept_id": "4077124",
+									"observation_event_id": "TREATMENT_0003~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "45884396",
+									"value_source_value": "Not available"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-13",
+									"observation_id": "TREATMENT_0003~OMOP_Surgery_Episode_Lymphovascular_Invasion_Observation",
+									"observation_concept_id": "1074673",
+									"observation_event_id": "TREATMENT_0003~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4132135",
+									"value_source_value": "Absent"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-13",
+									"observation_id": "TREATMENT_0003~OMOP_Surgery_Episode_Perineural_Invasion_Observation",
+									"observation_concept_id": "4161179",
+									"observation_event_id": "TREATMENT_0003~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4294169",
+									"value_source_value": "Not applicable"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-13",
+									"observation_id": "TREATMENT_0003~OMOP_Surgery_Episode_Margin_Positive_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0003~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Not available",
+									"qualifier_concept_id": "9191"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-13",
+									"observation_id": "TREATMENT_0003~OMOP_Surgery_Episode_Margin_Unassessible_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0003~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Common bile duct margin",
+									"qualifier_concept_id": "4183475"
+								}
+							},
+							{
+								"visit_occurrence": {
+									"visit_type_concept_id": "32879",
+									"visit_occurrence_id": "FOLLOW_UP_0002~OMOP_Follow_Up_Visit_Occurrence",
+									"visit_concept_id": "9202",
+									"visit_start_date": "2001-08-16",
+									"visit_end_date": "2001-08-16"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "FOLLOW_UP_0002~OMOP_Follow_Up_Relapse_Type_Observation",
+									"observation_concept_id": "4117444",
+									"observation_event_id": "FOLLOW_UP_0002~OMOP_Follow_Up_Visit_Occurrence",
+									"obs_event_field_concept_id": "1147070",
+									"value_as_concept_id": "36308003",
+									"value_source_value": "Biochemical progression"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0004~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-05-16",
+									"episode_number": "4188539"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0004~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Stem cell transplant...",
+									"procedure_date": "2000-05-16",
+									"modifier_concept_id": "9177",
+									"modifier_source_value": "Other"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0004~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0004~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-16",
+									"observation_id": "TREATMENT_0004~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0004~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "40491905",
+									"value_source_value": "Forensic"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-16",
+									"observation_id": "TREATMENT_0004~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36309215",
+									"value_source_value": "Immune stable disease (iSD)",
+									"observation_event_id": "TREATMENT_0004~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "Cheson CLL 2012 Oncology Response Criteria"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0004~OMOP_Radiation_Episode",
+									"episode_concept_id": "32940",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4165039",
+									"episode_start_date": "2000-05-16"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0004~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0004~OMOP_Radiation_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0004~OMOP_Radiation_Procedure",
+									"procedure_concept_id": "4165039",
+									"procedure_source_value": "Teleradiotherapy using electrons (procedure)",
+									"procedure_date": "2000-05-16"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0004~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0004~OMOP_Radiation_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-16",
+									"observation_id": "TREATMENT_0004~OMOP_Radiation_Episode_Radiated_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0004~OMOP_Radiation_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "36695706",
+									"value_source_value": "LEFT CHESTWALL BOOST"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0004~OMOP_Radiation_Boost_Procedure",
+									"procedure_concept_id": "40482853",
+									"procedure_date": "2000-05-16",
+									"modifier_concept_id": "4188540",
+									"modifier_source_value": "No"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0004~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0004~OMOP_Radiation_Boost_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "2000-08-12",
+									"episode_end_date": "2000-09-07"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0004~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "2000-08-12"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C68814|Nivolumab",
+									"drug_exposure_start_date": "2000-08-12",
+									"drug_exposure_end_date": "2000-09-07",
+									"dose_unit_source_value": "mg/m2"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C68814|Nivolumab",
+									"drug_exposure_start_date": "2000-08-12",
+									"drug_exposure_end_date": "2000-09-07",
+									"dose_unit_source_value": "mg/m2",
+									"quantity": 39.7
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4061650",
+									"episode_start_date": "2000-07-15",
+									"episode_end_date": "2000-09-07"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0004~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4061650",
+									"procedure_source_value": "Hormone therapy",
+									"procedure_date": "2000-07-15",
+									"quantity": 5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|16136245|Degarelix",
+									"drug_exposure_start_date": "2000-07-15",
+									"drug_exposure_end_date": "2000-09-07",
+									"dose_unit_source_value": "IU/kg",
+									"quantity": 70.9
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|16136245|Degarelix",
+									"drug_exposure_start_date": "2000-07-15",
+									"drug_exposure_end_date": "2000-09-07",
+									"dose_unit_source_value": "IU/kg",
+									"quantity": 36.9
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0004~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1991-03-05",
+									"measurement_event_id": "SPECIMEN_0002~OMOP_Specimen",
+									"meas_event_field_concept_id": "1147049",
+									"measurement_id": "DONOR_0002 + $.donors[1].biomarkers[0]~OMOP_PSA_Biomarker_Measurement",
+									"measurement_concept_id": "4272032",
+									"value_as_number": 34,
+									"unit_concept_id": "4120724"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1991-03-05",
+									"measurement_event_id": "SPECIMEN_0002~OMOP_Specimen",
+									"meas_event_field_concept_id": "1147049",
+									"measurement_id": "DONOR_0002 + $.donors[1].biomarkers[0]~OMOP_CA125_Biomarker_Measurement",
+									"measurement_concept_id": "4197913",
+									"value_as_number": 100,
+									"unit_concept_id": "4118305"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1991-03-05",
+									"measurement_event_id": "SPECIMEN_0002~OMOP_Specimen",
+									"meas_event_field_concept_id": "1147049",
+									"measurement_id": "DONOR_0002 + $.donors[1].biomarkers[0]~OMOP_CEA_Biomarker_Measurement",
+									"measurement_concept_id": "4244721",
+									"value_as_number": 43,
+									"unit_concept_id": "4120724"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1991-03-05",
+									"measurement_event_id": "SPECIMEN_0002~OMOP_Specimen",
+									"meas_event_field_concept_id": "1147049",
+									"measurement_id": "DONOR_0002 + $.donors[1].biomarkers[0]~OMOP_Estrogen_Receptor_Biomarker_Measurement",
+									"measurement_concept_id": "4307360",
+									"value_as_concept_id": "9191",
+									"value_as_number": 22.47,
+									"unit_concept_id": "4041099"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1991-03-05",
+									"measurement_event_id": "SPECIMEN_0002~OMOP_Specimen",
+									"meas_event_field_concept_id": "1147049",
+									"measurement_id": "DONOR_0002 + $.donors[1].biomarkers[0]~OMOP_HER2_IHC_Status_Biomarker_Measurement",
+									"measurement_concept_id": "35918264",
+									"value_as_concept_id": "607928"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1991-03-05",
+									"measurement_event_id": "SPECIMEN_0002~OMOP_Specimen",
+									"meas_event_field_concept_id": "1147049",
+									"measurement_id": "DONOR_0002 + $.donors[1].biomarkers[0]~OMOP_HER2_ISH_Status_Biomarker_Measurement",
+									"measurement_concept_id": "35918706",
+									"value_as_concept_id": "4294169"
+								}
+							}
+						]
+					},
+					{
+						"person": {
+							
+								"person_source_value": "SITE_PM2C~SYNTH_01~DONOR_0003",
+								"gender_concept_id": "8521",
+								"gender_source_value": "Other",
+								"year_of_birth": "1953",
+								"month_of_birth": "5",
+								"day_of_birth": "18",
+								"race_concept_id": "4255047",
+								"ethnicity_concept_id": "4255047"
+							
+						},
+						"linked_records": [
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "DONOR_0003~OMOP_Gender_Identity_Observation",
+									"observation_concept_id": "37171290",
+									"value_as_concept_id": "37171288",
+									"value_source_value": "Non-binary"
+								}
+							},
+							{
+								"death": {
+									"death_type_concept_id": "32879",
+									"death_date": "2012-08-05",
+									"cause_concept_id": "443392",
+									"cause_source_value": "Died of cancer"
+								}
+							},
+							{
+								"condition_occurrence": {
+									"condition_type_concept_id": "32879",
+									"condition_occurrence_id": "DIAG_0003~OMOP_Primary_Dx_Condition",
+									"condition_concept_id": "45755364",
+									"condition_source_value": "D38",
+									"condition_start_date": "2000-01-01",
+									"condition_status_concept_id": "32902"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "DIAG_0003~OMOP_Primary_Dx_Episode",
+									"episode_concept_id": "32528",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "45755364",
+									"episode_number": "1",
+									"episode_start_date": "2000-01-01",
+									"episode_end_date": "2000-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0003~OMOP_Primary_Dx_Episode",
+									"event_id": "DIAG_0003~OMOP_Primary_Dx_Condition",
+									"episode_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0003~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0003~OMOP_Primary_Dx_Initial_Diagnosis_Measurement",
+									"measurement_concept_id": "734306",
+									"value_as_concept_id": "4190367",
+									"value_source_value": "Histology of a primary tumour"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0003~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0003~OMOP_Primary_Dx_Laterality_Measurement",
+									"measurement_concept_id": "35918306",
+									"value_as_concept_id": "4280221",
+									"value_source_value": "Unilateral, side not specified"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-01",
+									"observation_id": "DIAG_0003~OMOP_Primary_Dx_Site_Observation",
+									"observation_concept_id": "3011717",
+									"value_as_concept_id": "44498119",
+									"value_source_value": "Colon",
+									"observation_event_id": "DIAG_0003~OMOP_Primary_Dx_Condition",
+									"obs_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0003~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0003~OMOP_Clinical_Stage_Measurement",
+									"measurement_concept_id": "4112450",
+									"measurement_source_value": "St Jude staging system",
+									"value_as_concept_id": "45878643",
+									"value_source_value": "Stage III"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0003~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0003~OMOP_Pathological_Stage_Measurement",
+									"measurement_concept_id": "1242682",
+									"measurement_source_value": "International Neuroblastoma..."
+								}
+							},
+							{
+								"specimen": {
+									"specimen_type_concept_id": "32879",
+									"specimen_id": "SPECIMEN_0003~OMOP_Specimen",
+									"specimen_concept_id": "4002890",
+									"specimen_date": "2000-01-29",
+									"anatomic_site_concept_id": "44497872",
+									"anatomic_site_source_value": "C54.8"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-29",
+									"observation_id": "SPECIMEN_0003~OMOP_Specimen_Tumour_Morphology_Observation",
+									"observation_concept_id": "36716952",
+									"observation_event_id": "SPECIMEN_0003~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "0",
+									"value_source_value": "9021/3"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-29",
+									"observation_id": "SPECIMEN_0003~OMOP_Specimen_Tumour_Grade_Observation",
+									"observation_concept_id": "4160340",
+									"observation_event_id": "SPECIMEN_0003~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4161667",
+									"value_source_value": "High",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "Four-tier grading system"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-29",
+									"observation_id": "SPECIMEN_0003~OMOP_Specimen_Processing_Technique_Observation",
+									"observation_concept_id": "4154128",
+									"observation_event_id": "SPECIMEN_0003~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4338536",
+									"value_source_value": "Cryopreservation in liquid nitrogen (dead tissue)"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-29",
+									"observation_id": "SPECIMEN_0003~OMOP_Specimen_Storage_Method_Observation",
+									"observation_concept_id": "37169821",
+									"observation_event_id": "SPECIMEN_0003~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "0",
+									"value_source_value": "OCT embedded"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0003~OMOP_Primary_Dx_Episode",
+									"event_id": "SPECIMEN_0003~OMOP_Specimen",
+									"episode_event_field_concept_id": "1147049"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0005~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "1800-01-01",
+									"episode_number": "4188540"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0005~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Surgery|Systemic therapy",
+									"procedure_date": "1800-01-01",
+									"modifier_concept_id": "0",
+									"modifier_source_value": "Treatment ongoing"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0005~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0005~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "TREATMENT_0005~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0005~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4324450",
+									"value_source_value": "Guidance"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "TREATMENT_0005~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36309727",
+									"value_source_value": "Complete remission with....",
+									"observation_event_id": "TREATMENT_0005~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "Blazer score"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4273629",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0005~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4273629",
+									"procedure_source_value": "Chemotherapy",
+									"procedure_date": "1800-01-01",
+									"quantity": 1
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"dose_unit_source_value": "mg",
+									"quantity": 64.2
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"dose_unit_source_value": "mg",
+									"quantity": 25.1
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0005~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "1800-01-01",
+									"quantity": 2
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|469690927|Atezolizumab",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"dose_unit_source_value": "IU/kg",
+									"quantity": 92.8
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|469690927|Atezolizumab",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"dose_unit_source_value": "IU/kg",
+									"quantity": 43.2
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0005~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0005~OMOP_Surgery_Episode",
+									"episode_concept_id": "32939",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0005~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0005~OMOP_Surgery_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0005~OMOP_Surgery_Procedure",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "NCIt|C15281|Total Mastectomy",
+									"procedure_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0005~OMOP_Surgery_Episode",
+									"event_id": "TREATMENT_0005~OMOP_Surgery_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1800-01-01",
+									"measurement_id": "TREATMENT_0005~OMOP_Surgery_Episode_Tumour_Length_Measurement",
+									"measurement_concept_id": "4156562",
+									"measurement_event_id": "TREATMENT_0005~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 5.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1800-01-01",
+									"measurement_id": "TREATMENT_0005~OMOP_Surgery_Episode_Greatest_Tumour_Dimension_Measurement",
+									"measurement_concept_id": "4154259",
+									"measurement_event_id": "TREATMENT_0005~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 3.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "TREATMENT_0005~OMOP_Surgery_Episode_Surgery_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0005~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "C02.9"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "TREATMENT_0005~OMOP_Surgery_Episode_Surgery_Tumour_Focality_Observation",
+									"observation_concept_id": "4244984",
+									"observation_event_id": "TREATMENT_0005~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4126041",
+									"value_source_value": "Unifocal"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "TREATMENT_0005~OMOP_Surgery_Episode_Residual_Tumour_Classification_Observation",
+									"observation_concept_id": "4077124",
+									"observation_event_id": "TREATMENT_0005~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "36308125",
+									"value_source_value": "R2"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "TREATMENT_0005~OMOP_Surgery_Episode_Lymphovascular_Invasion_Observation",
+									"observation_concept_id": "1074673",
+									"observation_event_id": "TREATMENT_0005~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4181412",
+									"value_source_value": "Present"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "TREATMENT_0005~OMOP_Surgery_Episode_Perineural_Invasion_Observation",
+									"observation_concept_id": "4161179",
+									"observation_event_id": "TREATMENT_0005~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4294169",
+									"value_source_value": "Not applicable"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "TREATMENT_0005~OMOP_Surgery_Episode_Margin_Positive_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0005~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Proximal margin|Common bile",
+									"qualifier_concept_id": "9191"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "TREATMENT_0005~OMOP_Surgery_Episode_Margin_Negative_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0005~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Proximal margin",
+									"qualifier_concept_id": "9189"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "TREATMENT_0005~OMOP_Surgery_Episode_Margin_Unassessible_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0005~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Distal margin",
+									"qualifier_concept_id": "4183475"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0006~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-03-30",
+									"episode_end_date": "2000-07-27",
+									"episode_number": "4188539"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0006~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Surgery|Radiation therapy|Systemic therapy",
+									"procedure_date": "2000-03-30",
+									"modifier_concept_id": "4191710",
+									"modifier_source_value": "Treatment stopped due to acute toxicity"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0006~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0006~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-30",
+									"observation_id": "TREATMENT_0006~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0006~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4161275",
+									"value_source_value": "Supportive"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-30",
+									"observation_id": "TREATMENT_0006~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36309215",
+									"value_source_value": "Physician assessed stable disease",
+									"observation_event_id": "TREATMENT_0006~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "Blazer score"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0006~OMOP_Radiation_Episode",
+									"episode_concept_id": "32940",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "40317890",
+									"episode_start_date": "2000-03-30"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0006~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0006~OMOP_Radiation_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0006~OMOP_Radiation_Procedure",
+									"procedure_concept_id": "40317890",
+									"procedure_source_value": "Brachytherapy (procedure)",
+									"procedure_date": "2000-03-30",
+									"modifier_concept_id": "4127806",
+									"modifier_source_value": "Internal"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0006~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0006~OMOP_Radiation_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-30",
+									"observation_id": "TREATMENT_0006~OMOP_Radiation_Episode_Radiated_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0006~OMOP_Radiation_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4312075",
+									"value_source_value": "RIGHT PAROTID"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0006~OMOP_Radiation_Boost_Procedure",
+									"procedure_concept_id": "40482853",
+									"procedure_date": "2000-03-30",
+									"modifier_concept_id": "4188540",
+									"modifier_source_value": "No"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0006~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0006~OMOP_Radiation_Boost_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0006~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "42629079",
+									"drug_source_value": "RxNorm|1792776|Atezolizumab",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"dose_unit_source_value": "g/m2",
+									"quantity": 84.3
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "42629079",
+									"drug_source_value": "RxNorm|1792776|Atezolizumab",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"dose_unit_source_value": "g/m2",
+									"quantity": 24.3
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4273629",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0006~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4273629",
+									"procedure_source_value": "Chemotherapy",
+									"procedure_date": "1800-01-01",
+									"quantity": 8
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"quantity": 75.5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0006~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "DONOR_0003 + $.donors[2].exposures[0]~OMOP_Tobacco_Smoking_Status_Observation",
+									"observation_concept_id": "43054909",
+									"value_as_concept_id": "4298794",
+									"value_source_value": "Current smoker"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "DONOR_0003 + $.donors[2].exposures[0]~OMOP_Cigarette_Pack_Years_Observation",
+									"observation_concept_id": "4151768",
+									"observation_event_id": "DONOR_0003 + $.donors[2].exposures[0]~OMOP_Tobacco_Smoking_Status_Observation",
+									"obs_event_field_concept_id": "1147165",
+									"value_as_number": 34
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "DONOR_0003 + $.donors[2].exposures[0]~OMOP_Tobacco_Type_Observation",
+									"observation_concept_id": "37172639",
+									"observation_event_id": "DONOR_0003 + $.donors[2].exposures[0]~OMOP_Tobacco_Smoking_Status_Observation",
+									"obs_event_field_concept_id": "1147165",
+									"value_as_concept_id": "0",
+									"value_source_value": "Not available"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1979-02-24",
+									"measurement_event_id": "DIAG_0003~OMOP_Primary_Dx_Episode",
+									"meas_event_field_concept_id": "798885",
+									"measurement_id": "DONOR_0003 + $.donors[2].biomarkers[0]~OMOP_PSA_Biomarker_Measurement",
+									"measurement_concept_id": "4272032",
+									"value_as_number": 1,
+									"unit_concept_id": "4120724"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1979-02-24",
+									"measurement_event_id": "DIAG_0003~OMOP_Primary_Dx_Episode",
+									"meas_event_field_concept_id": "798885",
+									"measurement_id": "DONOR_0003 + $.donors[2].biomarkers[0]~OMOP_CA125_Biomarker_Measurement",
+									"measurement_concept_id": "4197913",
+									"value_as_number": 57,
+									"unit_concept_id": "4118305"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1979-02-24",
+									"measurement_event_id": "DIAG_0003~OMOP_Primary_Dx_Episode",
+									"meas_event_field_concept_id": "798885",
+									"measurement_id": "DONOR_0003 + $.donors[2].biomarkers[0]~OMOP_CEA_Biomarker_Measurement",
+									"measurement_concept_id": "4244721",
+									"value_as_number": 78,
+									"unit_concept_id": "4120724"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1979-02-24",
+									"measurement_event_id": "DIAG_0003~OMOP_Primary_Dx_Episode",
+									"meas_event_field_concept_id": "798885",
+									"measurement_id": "DONOR_0003 + $.donors[2].biomarkers[0]~OMOP_Estrogen_Receptor_Biomarker_Measurement",
+									"measurement_concept_id": "4307360",
+									"value_as_concept_id": "607928",
+									"unit_concept_id": "4041099"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1979-02-24",
+									"measurement_event_id": "DIAG_0003~OMOP_Primary_Dx_Episode",
+									"meas_event_field_concept_id": "798885",
+									"measurement_id": "DONOR_0003 + $.donors[2].biomarkers[0]~OMOP_HER2_IHC_Status_Biomarker_Measurement",
+									"measurement_concept_id": "35918264",
+									"value_as_concept_id": "4172976"
+								}
+							}
+						]
+					},
+					{
+						"person": {
+						
+								"person_source_value": "SITE_PM2C~SYNTH_01~DONOR_ALL_0001",
+								"gender_concept_id": "8532",
+								"gender_source_value": "Female",
+								"year_of_birth": "1949",
+								"month_of_birth": "9",
+								"day_of_birth": "30",
+								"race_concept_id": "4255047",
+								"ethnicity_concept_id": "4255047"
+							
+						},
+						"linked_records": [
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "DONOR_ALL_0001~OMOP_Gender_Identity_Observation",
+									"observation_concept_id": "37171290",
+									"value_as_concept_id": "763768",
+									"value_source_value": "Man"
+								}
+							},
+							{
+								"death": {
+									"death_type_concept_id": "32879",
+									"death_date": "2011-02-22",
+									"cause_concept_id": "443392",
+									"cause_source_value": "Died of cancer"
+								}
+							},
+							{
+								"condition_occurrence": {
+									"condition_type_concept_id": "32879",
+									"condition_occurrence_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Condition",
+									"condition_concept_id": "45556961",
+									"condition_source_value": "C06.9",
+									"condition_start_date": "2000-01-01",
+									"condition_status_concept_id": "32902"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Episode",
+									"episode_concept_id": "32528",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "45556961",
+									"episode_number": "1",
+									"episode_start_date": "2000-01-01",
+									"episode_end_date": "2000-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Episode",
+									"event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Condition",
+									"episode_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Initial_Diagnosis_Measurement",
+									"measurement_concept_id": "734306",
+									"value_as_concept_id": "4190367",
+									"value_source_value": "Histology of a primary tumour"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Laterality_Measurement",
+									"measurement_concept_id": "35918306",
+									"value_as_concept_id": "36770232",
+									"value_source_value": "Left"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-01",
+									"observation_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Site_Observation",
+									"observation_concept_id": "3011717",
+									"value_as_concept_id": "44498037",
+									"value_source_value": "Floor of mouth",
+									"observation_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Condition",
+									"obs_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_ALL_0001~OMOP_TNM_Clin_T_Stage_Measurement",
+									"measurement_concept_id": "4164336",
+									"value_as_concept_id": "45881604",
+									"value_source_value": "T4a(m)"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_ALL_0001~OMOP_TNM_Clin_N_Stage_Measurement",
+									"measurement_concept_id": "4164466",
+									"value_as_concept_id": "46237062",
+									"value_source_value": "N1c"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_ALL_0001~OMOP_TNM_Clin_M_Stage_Measurement",
+									"measurement_concept_id": "4164182",
+									"value_as_concept_id": "45881618",
+									"value_source_value": "M1b(0)"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_ALL_0001~OMOP_Clinical_Stage_Measurement",
+									"measurement_concept_id": "1074424",
+									"measurement_source_value": "Durie-Salmon staging system",
+									"value_as_concept_id": "46237073",
+									"value_source_value": "Stage IES"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_ALL_0001~OMOP_TNM_Path_T_Stage_Measurement",
+									"measurement_concept_id": "4293617",
+									"value_as_concept_id": "45884279",
+									"value_source_value": "T2(s)"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_ALL_0001~OMOP_TNM_Path_N_Stage_Measurement",
+									"measurement_concept_id": "4161174",
+									"value_as_concept_id": "46237472",
+									"value_source_value": "N1mi"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_ALL_0001~OMOP_TNM_Path_M_Stage_Measurement",
+									"measurement_concept_id": "4154262",
+									"value_as_concept_id": "45882500",
+									"value_source_value": "M1a(0)"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_ALL_0001~OMOP_Pathological_Stage_Measurement",
+									"measurement_concept_id": "607102",
+									"measurement_source_value": "Rai staging system",
+									"value_as_concept_id": "0",
+									"value_source_value": "Stage IAS"
+								}
+							},
+							{
+								"specimen": {
+									"specimen_type_concept_id": "32879",
+									"specimen_id": "SPECIMEN_ALL_0001~OMOP_Specimen",
+									"specimen_concept_id": "4002890",
+									"specimen_date": "2000-01-22",
+									"anatomic_site_concept_id": "44498210",
+									"anatomic_site_source_value": "C41.1"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-22",
+									"observation_id": "SPECIMEN_ALL_0001~OMOP_Specimen_Tumour_Morphology_Observation",
+									"observation_concept_id": "36716952",
+									"observation_event_id": "SPECIMEN_ALL_0001~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "0",
+									"value_source_value": "9479/3"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-22",
+									"observation_id": "SPECIMEN_ALL_0001~OMOP_Specimen_Tumour_Grade_Observation",
+									"observation_concept_id": "4160340",
+									"observation_event_id": "SPECIMEN_ALL_0001~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "40459835",
+									"value_source_value": "Grade IV",
+									"qualifier_concept_id": "4161055",
+									"qualifier_source_value": "Nuclear grading system for DCIS"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-22",
+									"observation_id": "SPECIMEN_ALL_0001~OMOP_Specimen_Laterality_Observation",
+									"observation_concept_id": "4298494",
+									"observation_event_id": "SPECIMEN_ALL_0001~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4300877",
+									"value_source_value": "Left"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-22",
+									"observation_id": "SPECIMEN_ALL_0001~OMOP_Specimen_Processing_Technique_Observation",
+									"observation_concept_id": "4154128",
+									"observation_event_id": "SPECIMEN_ALL_0001~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4338536",
+									"value_source_value": "Cryopreservation in liquid nitrogen (dead tissue)"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-22",
+									"observation_id": "SPECIMEN_ALL_0001~OMOP_Specimen_Storage_Method_Observation",
+									"observation_concept_id": "37169821",
+									"observation_event_id": "SPECIMEN_ALL_0001~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "9177",
+									"value_source_value": "Other"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Episode",
+									"event_id": "SPECIMEN_ALL_0001~OMOP_Specimen",
+									"episode_event_field_concept_id": "1147049"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_ALL_0001~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-04-30",
+									"episode_end_date": "2001-01-20",
+									"episode_number": "4188540"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_ALL_0001~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Surgery|Systemic therapy",
+									"procedure_date": "2000-04-30",
+									"modifier_concept_id": "0",
+									"modifier_source_value": "Treatment ongoing"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0001~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_ALL_0001~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-30",
+									"observation_id": "TREATMENT_ALL_0001~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_ALL_0001~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4044554",
+									"value_source_value": "Preventive"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-30",
+									"observation_id": "TREATMENT_ALL_0001~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36309453",
+									"value_source_value": "Partial remission",
+									"observation_event_id": "TREATMENT_ALL_0001~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "Physician Assessed Response Criteria"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "2000-12-21",
+									"episode_end_date": "2001-01-11"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0001~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "2000-12-21",
+									"quantity": 2
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "40238188",
+									"drug_source_value": "RxNorm|1094833|Ipilimumab",
+									"drug_exposure_start_date": "2000-12-21",
+									"drug_exposure_end_date": "2001-01-11",
+									"dose_unit_source_value": "Not available",
+									"quantity": 72.5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "40238188",
+									"drug_source_value": "RxNorm|1094833|Ipilimumab",
+									"drug_exposure_start_date": "2000-12-21",
+									"drug_exposure_end_date": "2001-01-11",
+									"dose_unit_source_value": "Not available",
+									"quantity": 27.8
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4061650",
+									"episode_start_date": "2000-08-31",
+									"episode_end_date": "2000-09-21"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0001~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4061650",
+									"procedure_source_value": "Hormone therapy",
+									"procedure_date": "2000-08-31",
+									"quantity": 2
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "19033280",
+									"drug_source_value": "RxNorm|1825|Buserelin",
+									"drug_exposure_start_date": "2000-08-31",
+									"drug_exposure_end_date": "2000-09-21",
+									"dose_unit_source_value": "mg/m2"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "19033280",
+									"drug_source_value": "RxNorm|1825|Buserelin",
+									"drug_exposure_start_date": "2000-08-31",
+									"drug_exposure_end_date": "2000-09-21",
+									"dose_unit_source_value": "mg/m2"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_ALL_0001~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode",
+									"episode_concept_id": "32939",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4281521",
+									"episode_start_date": "2000-04-30"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0001~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_ALL_0001~OMOP_Surgery_Procedure",
+									"procedure_concept_id": "4281521",
+									"procedure_source_value": "SNOMED|66398006|Mastectomy...",
+									"procedure_date": "2000-04-30"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode",
+									"event_id": "TREATMENT_ALL_0001~OMOP_Surgery_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-04-30",
+									"measurement_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode_Tumour_Length_Measurement",
+									"measurement_concept_id": "4156562",
+									"measurement_event_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 6.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-04-30",
+									"measurement_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode_Tumour_Width_Measurement",
+									"measurement_concept_id": "4156563",
+									"measurement_event_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 9.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-04-30",
+									"measurement_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode_Greatest_Tumour_Dimension_Measurement",
+									"measurement_concept_id": "4154259",
+									"measurement_event_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 10.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-30",
+									"observation_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode_Surgery_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "C02.9"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-30",
+									"observation_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode_Surgery_Tumour_Focality_Observation",
+									"observation_concept_id": "4244984",
+									"observation_event_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4126041",
+									"value_source_value": "Unifocal"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-30",
+									"observation_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode_Surgery_Specimen_Source_Observation",
+									"observation_concept_id": "45773156",
+									"observation_event_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4032806",
+									"value_source_value": "Metastatic"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-30",
+									"observation_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode_Residual_Tumour_Classification_Observation",
+									"observation_concept_id": "4077124",
+									"observation_event_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "36307687",
+									"value_source_value": "R0"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-30",
+									"observation_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode_Lymphovascular_Invasion_Observation",
+									"observation_concept_id": "1074673",
+									"observation_event_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4181412",
+									"value_source_value": "Present"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-30",
+									"observation_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode_Perineural_Invasion_Observation",
+									"observation_concept_id": "4161179",
+									"observation_event_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "607928",
+									"value_source_value": "Cannot be assessed"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-30",
+									"observation_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode_Margin_Positive_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Circumferential resection",
+									"qualifier_concept_id": "9191"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-30",
+									"observation_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode_Margin_Negative_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Circumferential resection",
+									"qualifier_concept_id": "9189"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-30",
+									"observation_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode_Margin_Unassessible_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_ALL_0001~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Proximal margin",
+									"qualifier_concept_id": "4183475"
+								}
+							},
+							{
+								"visit_occurrence": {
+									"visit_type_concept_id": "32879",
+									"visit_occurrence_id": "FOLLOW_UP_ALL_0001~OMOP_Follow_Up_Visit_Occurrence",
+									"visit_concept_id": "9202",
+									"visit_start_date": "2002-05-01",
+									"visit_end_date": "2002-05-01"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2002-05-01",
+									"observation_id": "FOLLOW_UP_ALL_0001~OMOP_Follow_Up_Disease_Status_Observation",
+									"observation_concept_id": "4203711",
+									"observation_event_id": "FOLLOW_UP_ALL_0001~OMOP_Follow_Up_Visit_Occurrence",
+									"obs_event_field_concept_id": "1147070",
+									"value_as_concept_id": "36310520",
+									"value_source_value": "No evidence of disease"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "FOLLOW_UP_ALL_0001~OMOP_Follow_Up_Relapse_Type_Observation",
+									"observation_concept_id": "4117444",
+									"observation_event_id": "FOLLOW_UP_ALL_0001~OMOP_Follow_Up_Visit_Occurrence",
+									"obs_event_field_concept_id": "1147070",
+									"value_as_concept_id": "1619237",
+									"value_source_value": "Local recurrence and distant metastasis"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_ALL_0002~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-01-23",
+									"episode_end_date": "2000-12-29",
+									"episode_number": "4188540"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_ALL_0002~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Radiation therapy|Systemic therapy",
+									"procedure_date": "2000-01-23",
+									"modifier_concept_id": "4191710",
+									"modifier_source_value": "Treatment stopped due to acute toxicity"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0002~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_ALL_0002~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-23",
+									"observation_id": "TREATMENT_ALL_0002~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_ALL_0002~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4179711",
+									"value_source_value": "Palliative"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-23",
+									"observation_id": "TREATMENT_ALL_0002~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36309453",
+									"value_source_value": "Immune partial response (iPR)",
+									"observation_event_id": "TREATMENT_ALL_0002~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "Blazer score"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_ALL_0002~OMOP_Radiation_Episode",
+									"episode_concept_id": "32940",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "40317890",
+									"episode_start_date": "2000-01-23"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0002~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_ALL_0002~OMOP_Radiation_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_ALL_0002~OMOP_Radiation_Procedure",
+									"procedure_concept_id": "40317890",
+									"procedure_source_value": "Brachytherapy (procedure)",
+									"procedure_date": "2000-01-23",
+									"modifier_concept_id": "4130085",
+									"modifier_source_value": "External"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0002~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_ALL_0002~OMOP_Radiation_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-23",
+									"measurement_id": "TREATMENT_ALL_0002~OMOP_Radiation_Episode_Total_Dose_Given_Measurement",
+									"measurement_concept_id": "40483776",
+									"measurement_event_id": "TREATMENT_ALL_0002~OMOP_Radiation_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 75,
+									"unit_concept_id": "4037797"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-23",
+									"measurement_id": "TREATMENT_ALL_0002~OMOP_Radiation_Episode_Total_Fractions_Given_Measurement",
+									"measurement_concept_id": "4037631",
+									"measurement_event_id": "TREATMENT_ALL_0002~OMOP_Radiation_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 24
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-23",
+									"observation_id": "TREATMENT_ALL_0002~OMOP_Radiation_Episode_Radiated_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_ALL_0002~OMOP_Radiation_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4274743",
+									"value_source_value": "UPPER RIGHT ARM"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_ALL_0002~OMOP_Radiation_Boost_Procedure",
+									"procedure_concept_id": "40482853",
+									"procedure_date": "2000-01-23",
+									"modifier_concept_id": "4188540",
+									"modifier_source_value": "No"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0002~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_ALL_0002~OMOP_Radiation_Boost_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "2000-02-02",
+									"episode_end_date": "2000-10-28"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0002~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "2000-02-02",
+									"quantity": 5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|469690927|Atezolizumab",
+									"drug_exposure_start_date": "2000-02-02",
+									"drug_exposure_end_date": "2000-10-28",
+									"dose_unit_source_value": "mg/kg",
+									"quantity": 60.5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|469690927|Atezolizumab",
+									"drug_exposure_start_date": "2000-02-02",
+									"drug_exposure_end_date": "2000-10-28",
+									"dose_unit_source_value": "mg/kg"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4061650",
+									"episode_start_date": "2000-02-08",
+									"episode_end_date": "2000-03-31"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0002~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4061650",
+									"procedure_source_value": "Hormone therapy",
+									"procedure_date": "2000-02-08",
+									"quantity": 4
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "1525866",
+									"drug_source_value": "RxNorm|3390|Diethylstilbestrol",
+									"drug_exposure_start_date": "2000-02-08",
+									"drug_exposure_end_date": "2000-03-31",
+									"dose_unit_source_value": "IU/m2"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "1525866",
+									"drug_source_value": "RxNorm|3390|Diethylstilbestrol",
+									"drug_exposure_start_date": "2000-02-08",
+									"drug_exposure_end_date": "2000-03-31",
+									"dose_unit_source_value": "IU/m2",
+									"quantity": 33.6
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_ALL_0002~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "DONOR_ALL_0001 + $.donors[6].exposures[0]~OMOP_Tobacco_Smoking_Status_Observation",
+									"observation_concept_id": "43054909",
+									"value_as_concept_id": "4294169",
+									"value_source_value": "Not applicable"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1987-10-14",
+									"measurement_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Episode",
+									"meas_event_field_concept_id": "798885",
+									"measurement_id": "DONOR_ALL_0001 + $.donors[6].biomarkers[0]~OMOP_PSA_Biomarker_Measurement",
+									"measurement_concept_id": "4272032",
+									"value_as_number": 99,
+									"unit_concept_id": "4120724"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1987-10-14",
+									"measurement_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Episode",
+									"meas_event_field_concept_id": "798885",
+									"measurement_id": "DONOR_ALL_0001 + $.donors[6].biomarkers[0]~OMOP_CA125_Biomarker_Measurement",
+									"measurement_concept_id": "4197913",
+									"value_as_number": 27,
+									"unit_concept_id": "4118305"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1987-10-14",
+									"measurement_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Episode",
+									"meas_event_field_concept_id": "798885",
+									"measurement_id": "DONOR_ALL_0001 + $.donors[6].biomarkers[0]~OMOP_CEA_Biomarker_Measurement",
+									"measurement_concept_id": "4244721",
+									"value_as_number": 98,
+									"unit_concept_id": "4120724"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1987-10-14",
+									"measurement_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Episode",
+									"meas_event_field_concept_id": "798885",
+									"measurement_id": "DONOR_ALL_0001 + $.donors[6].biomarkers[0]~OMOP_Estrogen_Receptor_Biomarker_Measurement",
+									"measurement_concept_id": "4307360",
+									"value_as_concept_id": "4294169",
+									"unit_concept_id": "4041099"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1987-10-14",
+									"measurement_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Episode",
+									"meas_event_field_concept_id": "798885",
+									"measurement_id": "DONOR_ALL_0001 + $.donors[6].biomarkers[0]~OMOP_HER2_IHC_Status_Biomarker_Measurement",
+									"measurement_concept_id": "35918264",
+									"value_as_concept_id": "9189"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1987-10-14",
+									"measurement_event_id": "DIAG_ALL_0001~OMOP_Primary_Dx_Episode",
+									"meas_event_field_concept_id": "798885",
+									"measurement_id": "DONOR_ALL_0001 + $.donors[6].biomarkers[0]~OMOP_HER2_ISH_Status_Biomarker_Measurement",
+									"measurement_concept_id": "35918706",
+									"value_as_concept_id": "4294169"
+								}
+							}
+						]
+					},
+					{
+						"person": {
+							
+								"person_source_value": "SITE_PM2C~SYNTH_01~DONOR_NULL_0001",
+								"gender_concept_id": "4255047",
+								"year_of_birth": "1800",
+								"month_of_birth": "1",
+								"day_of_birth": "1",
+								"race_concept_id": "4255047",
+								"ethnicity_concept_id": "4255047"
+							
+						},
+						"linked_records": [
+							{
+								"death": {
+									"death_type_concept_id": "32879",
+									"death_date": "1800-01-01"
+								}
+							},
+							{
+								"condition_occurrence": {
+									"condition_type_concept_id": "32879",
+									"condition_occurrence_id": "DIAG_NULL_0001~OMOP_Primary_Dx_Condition",
+									"condition_concept_id": "4255047",
+									"condition_start_date": "1800-01-01",
+									"condition_status_concept_id": "32902"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "DIAG_NULL_0001~OMOP_Primary_Dx_Episode",
+									"episode_concept_id": "32528",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4255047",
+									"episode_number": "1",
+									"episode_start_date": "2000-01-01",
+									"episode_end_date": "2000-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_NULL_0001~OMOP_Primary_Dx_Episode",
+									"event_id": "DIAG_NULL_0001~OMOP_Primary_Dx_Condition",
+									"episode_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_NULL_0001~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_NULL_0001~OMOP_Primary_Dx_Initial_Diagnosis_Measurement",
+									"measurement_concept_id": "734306"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_NULL_0001~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_NULL_0001~OMOP_Clinical_Stage_Measurement",
+									"measurement_concept_id": "4255047"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_NULL_0001~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_NULL_0001~OMOP_Pathological_Stage_Measurement",
+									"measurement_concept_id": "4255047"
+								}
+							},
+							{
+								"specimen": {
+									"specimen_type_concept_id": "32879",
+									"specimen_id": "SPECIMEN_NULL_0001~OMOP_Specimen",
+									"specimen_concept_id": "4002890",
+									"specimen_date": "1800-01-01"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "SPECIMEN_NULL_0001~OMOP_Specimen_Tumour_Grade_Observation",
+									"observation_concept_id": "4160340",
+									"observation_event_id": "SPECIMEN_NULL_0001~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4255047"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_NULL_0001~OMOP_Primary_Dx_Episode",
+									"event_id": "SPECIMEN_NULL_0001~OMOP_Specimen",
+									"episode_event_field_concept_id": "1147049"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_NULL_0001~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_NULL_0001~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Surgery|Systemic therapy",
+									"procedure_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0001~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_NULL_0001~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "TREATMENT_NULL_0001~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "4255047",
+									"observation_event_id": "TREATMENT_NULL_0001~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4273629",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0001~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4273629",
+									"procedure_source_value": "Chemotherapy",
+									"procedure_date": "1800-01-01",
+									"quantity": 5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4061650",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0001~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4061650",
+									"procedure_source_value": "Hormone therapy",
+									"procedure_date": "1800-01-01",
+									"quantity": 9
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_NULL_0001~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_NULL_0001~OMOP_Surgery_Episode",
+									"episode_concept_id": "32939",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4255047",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0001~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_NULL_0001~OMOP_Surgery_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_NULL_0001~OMOP_Surgery_Procedure",
+									"procedure_concept_id": "4255047",
+									"procedure_source_value": "CCI|fSxOBynIFIkxubG",
+									"procedure_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0001~OMOP_Surgery_Episode",
+									"event_id": "TREATMENT_NULL_0001~OMOP_Surgery_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_NULL_0002~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_NULL_0002~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Systemic therapy",
+									"procedure_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0002~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_NULL_0002~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "TREATMENT_NULL_0002~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "4255047",
+									"observation_event_id": "TREATMENT_NULL_0002~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_NULL_0002~OMOP_Radiation_Episode",
+									"episode_concept_id": "32940",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4255047",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0002~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_NULL_0002~OMOP_Radiation_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_NULL_0002~OMOP_Radiation_Procedure",
+									"procedure_concept_id": "4255047",
+									"procedure_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0002~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_NULL_0002~OMOP_Radiation_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4061650",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0002~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4061650",
+									"procedure_source_value": "Hormone therapy",
+									"procedure_date": "1800-01-01",
+									"quantity": 5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4273629",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0002~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4273629",
+									"procedure_source_value": "Chemotherapy",
+									"procedure_date": "1800-01-01",
+									"quantity": 5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_NULL_0002~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							}
+						]
+					},
+					{
+						"person": {
+						
+								"person_source_value": "SITE_PM2C~SYNTH_01~DONOR_0004",
+								"gender_concept_id": "8507",
+								"gender_source_value": "Male",
+								"year_of_birth": "1958",
+								"month_of_birth": "4",
+								"day_of_birth": "12",
+								"race_concept_id": "4255047",
+								"ethnicity_concept_id": "4255047"
+							
+						},
+						"linked_records": [
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "DONOR_0004~OMOP_Gender_Identity_Observation",
+									"observation_concept_id": "37171290",
+									"value_as_concept_id": "763768",
+									"value_source_value": "Man"
+								}
+							},
+							{
+								"death": {
+									"death_type_concept_id": "32879",
+									"death_date": "1800-01-01"
+								}
+							},
+							{
+								"condition_occurrence": {
+									"condition_type_concept_id": "32879",
+									"condition_occurrence_id": "DIAG_0004~OMOP_Primary_Dx_Condition",
+									"condition_concept_id": "45581203",
+									"condition_source_value": "C26",
+									"condition_start_date": "2000-01-01",
+									"condition_status_concept_id": "32902"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "DIAG_0004~OMOP_Primary_Dx_Episode",
+									"episode_concept_id": "32528",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "45581203",
+									"episode_number": "1",
+									"episode_start_date": "2000-01-01",
+									"episode_end_date": "2000-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0004~OMOP_Primary_Dx_Episode",
+									"event_id": "DIAG_0004~OMOP_Primary_Dx_Condition",
+									"episode_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0004~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0004~OMOP_Primary_Dx_Initial_Diagnosis_Measurement",
+									"measurement_concept_id": "734306",
+									"value_as_concept_id": "439401",
+									"value_source_value": "Cytology"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0004~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0004~OMOP_Primary_Dx_Laterality_Measurement",
+									"measurement_concept_id": "35918306",
+									"value_as_concept_id": "36770232",
+									"value_source_value": "Left"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-01",
+									"observation_id": "DIAG_0004~OMOP_Primary_Dx_Site_Observation",
+									"observation_concept_id": "3011717",
+									"value_as_concept_id": "44498222",
+									"value_source_value": "Skin",
+									"observation_event_id": "DIAG_0004~OMOP_Primary_Dx_Condition",
+									"obs_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0004~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0004~OMOP_Clinical_Stage_Measurement",
+									"measurement_concept_id": "607090",
+									"measurement_source_value": "Binet staging system",
+									"value_as_concept_id": "45881861",
+									"value_source_value": "Stage C"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0004~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0004~OMOP_Pathological_Stage_Measurement",
+									"measurement_concept_id": "4115000",
+									"measurement_source_value": "Ann Arbor staging system",
+									"value_as_concept_id": "0",
+									"value_source_value": "Stage IIIB"
+								}
+							},
+							{
+								"specimen": {
+									"specimen_type_concept_id": "32879",
+									"specimen_id": "SPECIMEN_0004~OMOP_Specimen",
+									"specimen_concept_id": "4002890",
+									"specimen_date": "1800-01-01",
+									"anatomic_site_concept_id": "44498250",
+									"anatomic_site_source_value": "C49.1"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "SPECIMEN_0004~OMOP_Specimen_Tumour_Morphology_Observation",
+									"observation_concept_id": "36716952",
+									"observation_event_id": "SPECIMEN_0004~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "0",
+									"value_source_value": "9030/3"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "SPECIMEN_0004~OMOP_Specimen_Tumour_Grade_Observation",
+									"observation_concept_id": "4160340",
+									"observation_event_id": "SPECIMEN_0004~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "37164076",
+									"value_source_value": "G2",
+									"qualifier_concept_id": "4139510",
+									"qualifier_source_value": "FNCLCC grading system"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "SPECIMEN_0004~OMOP_Specimen_Storage_Method_Observation",
+									"observation_concept_id": "37169821",
+									"observation_event_id": "SPECIMEN_0004~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4294169",
+									"value_source_value": "Not Applicable"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0004~OMOP_Primary_Dx_Episode",
+									"event_id": "SPECIMEN_0004~OMOP_Specimen",
+									"episode_event_field_concept_id": "1147049"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0007~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-02-14",
+									"episode_end_date": "2000-09-28",
+									"episode_number": "4188540"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0007~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Surgery|Systemic therapy",
+									"procedure_date": "2000-02-14",
+									"modifier_concept_id": "4191710",
+									"modifier_source_value": "Treatment incomplete because patient died"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0007~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0007~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-14",
+									"observation_id": "TREATMENT_0007~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0007~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4162591",
+									"value_source_value": "Curative"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-14",
+									"observation_id": "TREATMENT_0007~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36310520",
+									"value_source_value": "No evidence of disease (NED)",
+									"observation_event_id": "TREATMENT_0007~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "Response Assessment in Neuro-Oncology (RANO)"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4273629",
+									"episode_start_date": "2000-06-20",
+									"episode_end_date": "2000-07-18"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0007~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4273629",
+									"procedure_source_value": "Chemotherapy",
+									"procedure_date": "2000-06-20"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "1395557",
+									"drug_source_value": "RxNorm|24698|Fludarabine",
+									"drug_exposure_start_date": "2000-06-20",
+									"drug_exposure_end_date": "2000-07-18",
+									"dose_unit_source_value": "ug/m2",
+									"quantity": 77.4
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "1395557",
+									"drug_source_value": "RxNorm|24698|Fludarabine",
+									"drug_exposure_start_date": "2000-06-20",
+									"drug_exposure_end_date": "2000-07-18",
+									"dose_unit_source_value": "ug/m2",
+									"quantity": 38.2
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4273629",
+									"episode_start_date": "2000-05-25",
+									"episode_end_date": "2000-07-26"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0007~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4273629",
+									"procedure_source_value": "Chemotherapy",
+									"procedure_date": "2000-05-25",
+									"quantity": 9
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|426756|Carboplatin",
+									"drug_exposure_start_date": "2000-05-25",
+									"drug_exposure_end_date": "2000-07-26",
+									"dose_unit_source_value": "mg/m2",
+									"quantity": 62.5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|426756|Carboplatin",
+									"drug_exposure_start_date": "2000-05-25",
+									"drug_exposure_end_date": "2000-07-26",
+									"dose_unit_source_value": "mg/m2",
+									"quantity": 20.8
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0007~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0007~OMOP_Surgery_Episode",
+									"episode_concept_id": "32939",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-02-14"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0007~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0007~OMOP_Surgery_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0007~OMOP_Surgery_Procedure",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "UMLS|C0399839|Bypass Gastrojejunostomy",
+									"procedure_date": "2000-02-14"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0007~OMOP_Surgery_Episode",
+									"event_id": "TREATMENT_0007~OMOP_Surgery_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-02-14",
+									"measurement_id": "TREATMENT_0007~OMOP_Surgery_Episode_Tumour_Length_Measurement",
+									"measurement_concept_id": "4156562",
+									"measurement_event_id": "TREATMENT_0007~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 1.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-02-14",
+									"measurement_id": "TREATMENT_0007~OMOP_Surgery_Episode_Tumour_Width_Measurement",
+									"measurement_concept_id": "4156563",
+									"measurement_event_id": "TREATMENT_0007~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 9.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-02-14",
+									"measurement_id": "TREATMENT_0007~OMOP_Surgery_Episode_Greatest_Tumour_Dimension_Measurement",
+									"measurement_concept_id": "4154259",
+									"measurement_event_id": "TREATMENT_0007~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 10.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-14",
+									"observation_id": "TREATMENT_0007~OMOP_Surgery_Episode_Surgery_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0007~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "C71.8"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-14",
+									"observation_id": "TREATMENT_0007~OMOP_Surgery_Episode_Surgery_Tumour_Focality_Observation",
+									"observation_concept_id": "4244984",
+									"observation_event_id": "TREATMENT_0007~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "45884396",
+									"value_source_value": "Not available"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-14",
+									"observation_id": "TREATMENT_0007~OMOP_Surgery_Episode_Surgery_Specimen_Source_Observation",
+									"observation_concept_id": "45773156",
+									"observation_event_id": "TREATMENT_0007~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4032806",
+									"value_source_value": "Metastatic"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-14",
+									"observation_id": "TREATMENT_0007~OMOP_Surgery_Episode_Residual_Tumour_Classification_Observation",
+									"observation_concept_id": "4077124",
+									"observation_event_id": "TREATMENT_0007~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4294169",
+									"value_source_value": "Not applicable"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-14",
+									"observation_id": "TREATMENT_0007~OMOP_Surgery_Episode_Lymphovascular_Invasion_Observation",
+									"observation_concept_id": "1074673",
+									"observation_event_id": "TREATMENT_0007~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4299336",
+									"value_source_value": "Lymphatic and small vessel invasion only"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-14",
+									"observation_id": "TREATMENT_0007~OMOP_Surgery_Episode_Perineural_Invasion_Observation",
+									"observation_concept_id": "4161179",
+									"observation_event_id": "TREATMENT_0007~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "45884396",
+									"value_source_value": "Not available"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-14",
+									"observation_id": "TREATMENT_0007~OMOP_Surgery_Episode_Margin_Positive_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0007~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Not available|Not applicable",
+									"qualifier_concept_id": "9191"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-14",
+									"observation_id": "TREATMENT_0007~OMOP_Surgery_Episode_Margin_Negative_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0007~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Distal margin",
+									"qualifier_concept_id": "9189"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0008~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-02-20",
+									"episode_end_date": "2000-06-15",
+									"episode_number": "4188540"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0008~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Systemic therapy",
+									"procedure_date": "2000-02-20",
+									"modifier_concept_id": "0",
+									"modifier_source_value": "Treatment ongoing"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0008~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0008~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-20",
+									"observation_id": "TREATMENT_0008~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0008~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "40491905",
+									"value_source_value": "Forensic"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-20",
+									"observation_id": "TREATMENT_0008~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36309727",
+									"value_source_value": "Complete remission with...",
+									"observation_event_id": "TREATMENT_0008~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0008~OMOP_Radiation_Episode",
+									"episode_concept_id": "32940",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "40489482",
+									"episode_start_date": "2000-02-20"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0008~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0008~OMOP_Radiation_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0008~OMOP_Radiation_Procedure",
+									"procedure_concept_id": "40489482",
+									"procedure_source_value": "Megavoltage radiation therap",
+									"procedure_date": "2000-02-20"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0008~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0008~OMOP_Radiation_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-02-20",
+									"measurement_id": "TREATMENT_0008~OMOP_Radiation_Episode_Total_Dose_Given_Measurement",
+									"measurement_concept_id": "40483776",
+									"measurement_event_id": "TREATMENT_0008~OMOP_Radiation_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 9,
+									"unit_concept_id": "4037797"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-20",
+									"observation_id": "TREATMENT_0008~OMOP_Radiation_Episode_Radiated_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0008~OMOP_Radiation_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4230443",
+									"value_source_value": "BILATERAL EYES"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0008~OMOP_Radiation_Boost_Procedure",
+									"procedure_concept_id": "40482853",
+									"procedure_date": "2000-02-20",
+									"modifier_concept_id": "4188540",
+									"modifier_source_value": "No"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0008~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0008~OMOP_Radiation_Boost_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0008~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"dose_unit_source_value": "IU/kg",
+									"quantity": 62.6
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"dose_unit_source_value": "IU/kg",
+									"quantity": 46.6
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4061650",
+									"episode_start_date": "2000-05-31",
+									"episode_end_date": "2000-05-31"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0008~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4061650",
+									"procedure_source_value": "Hormone therapy",
+									"procedure_date": "2000-05-31",
+									"quantity": 6
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "2000-05-31",
+									"drug_exposure_end_date": "2000-05-31",
+									"quantity": 64.3
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "4255047",
+									"drug_exposure_start_date": "2000-05-31",
+									"drug_exposure_end_date": "2000-05-31",
+									"quantity": 33.9
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0008~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "DONOR_0004 + $.donors[8].exposures[0]~OMOP_Tobacco_Smoking_Status_Observation",
+									"observation_concept_id": "43054909",
+									"value_as_concept_id": "4222303",
+									"value_source_value": "Lifelong non-smoker..."
+								}
+							}
+						]
+					},
+					{
+						"person": {
+							
+								"person_source_value": "SITE_PM2C~SYNTH_01~DONOR_0005",
+								"gender_concept_id": "4255047",
+								"year_of_birth": "1948",
+								"month_of_birth": "4",
+								"day_of_birth": "29",
+								"race_concept_id": "4255047",
+								"ethnicity_concept_id": "4255047"
+							
+						},
+						"linked_records": [
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "DONOR_0005~OMOP_Gender_Identity_Observation",
+									"observation_concept_id": "37171290",
+									"value_as_concept_id": "9177",
+									"value_source_value": "Other"
+								}
+							},
+							{
+								"death": {
+									"death_type_concept_id": "32879",
+									"death_date": "2035-02-20",
+									"cause_concept_id": "45884396",
+									"cause_source_value": "Not available"
+								}
+							},
+							{
+								"condition_occurrence": {
+									"condition_type_concept_id": "32879",
+									"condition_occurrence_id": "DIAG_0005~OMOP_Primary_Dx_Condition",
+									"condition_concept_id": "45585982",
+									"condition_source_value": "C04",
+									"condition_start_date": "2000-01-01",
+									"condition_status_concept_id": "32902"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "DIAG_0005~OMOP_Primary_Dx_Episode",
+									"episode_concept_id": "32528",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "45585982",
+									"episode_number": "1",
+									"episode_start_date": "2000-01-01",
+									"episode_end_date": "2000-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0005~OMOP_Primary_Dx_Episode",
+									"event_id": "DIAG_0005~OMOP_Primary_Dx_Condition",
+									"episode_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0005~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0005~OMOP_Primary_Dx_Initial_Diagnosis_Measurement",
+									"measurement_concept_id": "734306"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0005~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0005~OMOP_Primary_Dx_Laterality_Measurement",
+									"measurement_concept_id": "35918306",
+									"value_as_concept_id": "36770109",
+									"value_source_value": "Bilateral"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0005~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0005~OMOP_Clinical_Stage_Measurement",
+									"measurement_concept_id": "607126",
+									"measurement_source_value": "Revised International staging system (R-ISS)",
+									"value_as_concept_id": "45880978",
+									"value_source_value": "Stage IIIAS"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0005~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0005~OMOP_Pathological_Stage_Measurement",
+									"measurement_concept_id": "4255047",
+									"value_as_concept_id": "0",
+									"value_source_value": "Stage IVBES"
+								}
+							},
+							{
+								"specimen": {
+									"specimen_type_concept_id": "32879",
+									"specimen_id": "SPECIMEN_0005~OMOP_Specimen",
+									"specimen_concept_id": "4002890",
+									"specimen_date": "2000-03-22",
+									"anatomic_site_concept_id": "44498151",
+									"anatomic_site_source_value": "C25.1"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-22",
+									"observation_id": "SPECIMEN_0005~OMOP_Specimen_Tumour_Morphology_Observation",
+									"observation_concept_id": "36716952",
+									"observation_event_id": "SPECIMEN_0005~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "0",
+									"value_source_value": "8207/3"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-22",
+									"observation_id": "SPECIMEN_0005~OMOP_Specimen_Tumour_Grade_Observation",
+									"observation_concept_id": "4160340",
+									"observation_event_id": "SPECIMEN_0005~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4255047",
+									"qualifier_concept_id": "37154145",
+									"qualifier_source_value": "ISUP grading system"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-22",
+									"observation_id": "SPECIMEN_0005~OMOP_Specimen_Laterality_Observation",
+									"observation_concept_id": "4298494",
+									"observation_event_id": "SPECIMEN_0005~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4080761",
+									"value_source_value": "Right"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-22",
+									"observation_id": "SPECIMEN_0005~OMOP_Specimen_Processing_Technique_Observation",
+									"observation_concept_id": "4154128",
+									"observation_event_id": "SPECIMEN_0005~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4126854",
+									"value_source_value": "Fresh"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-22",
+									"observation_id": "SPECIMEN_0005~OMOP_Specimen_Storage_Method_Observation",
+									"observation_concept_id": "37169821",
+									"observation_event_id": "SPECIMEN_0005~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "0",
+									"value_source_value": "RNA later frozen"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0005~OMOP_Primary_Dx_Episode",
+									"event_id": "SPECIMEN_0005~OMOP_Specimen",
+									"episode_event_field_concept_id": "1147049"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0009~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-02-27",
+									"episode_end_date": "2001-02-22",
+									"episode_number": "4188539"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0009~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Radiation therapy|Surgery|Systemic therapy",
+									"procedure_date": "2000-02-27",
+									"modifier_concept_id": "4082735",
+									"modifier_source_value": "Treatment completed as prescribed"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0009~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0009~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-27",
+									"observation_id": "TREATMENT_0009~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0009~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4044554",
+									"value_source_value": "Preventive"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-27",
+									"observation_id": "TREATMENT_0009~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36310520",
+									"value_source_value": "No evidence of disease (NED)",
+									"observation_event_id": "TREATMENT_0009~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "RECIST 1.1"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4061650",
+									"episode_start_date": "2000-09-07",
+									"episode_end_date": "2000-12-25"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0009~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4061650",
+									"procedure_source_value": "Hormone therapy",
+									"procedure_date": "2000-09-07"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|448537|Diethylstilbestrol",
+									"drug_exposure_start_date": "2000-09-07",
+									"drug_exposure_end_date": "2000-12-25",
+									"dose_unit_source_value": "mg/kg",
+									"quantity": 86.8
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|448537|Diethylstilbestrol",
+									"drug_exposure_start_date": "2000-09-07",
+									"drug_exposure_end_date": "2000-12-25",
+									"dose_unit_source_value": "mg/kg",
+									"quantity": 48.1
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4061650",
+									"episode_start_date": "2000-05-17",
+									"episode_end_date": "2000-07-27"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0009~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4061650",
+									"procedure_source_value": "Hormone therapy",
+									"procedure_date": "2000-05-17",
+									"quantity": 1
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C507|Fluoxymesterone",
+									"drug_exposure_start_date": "2000-05-17",
+									"drug_exposure_end_date": "2000-07-27",
+									"dose_unit_source_value": "mg/m2",
+									"quantity": 67.6
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C507|Fluoxymesterone",
+									"drug_exposure_start_date": "2000-05-17",
+									"drug_exposure_end_date": "2000-07-27",
+									"dose_unit_source_value": "mg/m2",
+									"quantity": 46.7
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0009~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0009~OMOP_Surgery_Episode",
+									"episode_concept_id": "32939",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4281521",
+									"episode_start_date": "2000-02-27"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0009~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0009~OMOP_Surgery_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0009~OMOP_Surgery_Procedure",
+									"procedure_concept_id": "4281521",
+									"procedure_source_value": "SNOMED|66398006|Mastectomy...",
+									"procedure_date": "2000-02-27"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0009~OMOP_Surgery_Episode",
+									"event_id": "TREATMENT_0009~OMOP_Surgery_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-02-27",
+									"measurement_id": "TREATMENT_0009~OMOP_Surgery_Episode_Tumour_Length_Measurement",
+									"measurement_concept_id": "4156562",
+									"measurement_event_id": "TREATMENT_0009~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 6.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-02-27",
+									"measurement_id": "TREATMENT_0009~OMOP_Surgery_Episode_Greatest_Tumour_Dimension_Measurement",
+									"measurement_concept_id": "4154259",
+									"measurement_event_id": "TREATMENT_0009~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 4.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-27",
+									"observation_id": "TREATMENT_0009~OMOP_Surgery_Episode_Surgery_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0009~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "C11.8"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-27",
+									"observation_id": "TREATMENT_0009~OMOP_Surgery_Episode_Surgery_Tumour_Focality_Observation",
+									"observation_concept_id": "4244984",
+									"observation_event_id": "TREATMENT_0009~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4294169",
+									"value_source_value": "Not applicable"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-27",
+									"observation_id": "TREATMENT_0009~OMOP_Surgery_Episode_Surgery_Specimen_Source_Observation",
+									"observation_concept_id": "45773156",
+									"observation_event_id": "TREATMENT_0009~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4097297",
+									"value_source_value": "Local recurrence"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-27",
+									"observation_id": "TREATMENT_0009~OMOP_Surgery_Episode_Lymphovascular_Invasion_Observation",
+									"observation_concept_id": "1074673",
+									"observation_event_id": "TREATMENT_0009~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4181412",
+									"value_source_value": "Present"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-27",
+									"observation_id": "TREATMENT_0009~OMOP_Surgery_Episode_Perineural_Invasion_Observation",
+									"observation_concept_id": "4161179",
+									"observation_event_id": "TREATMENT_0009~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4181412",
+									"value_source_value": "Present"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-27",
+									"observation_id": "TREATMENT_0009~OMOP_Surgery_Episode_Margin_Positive_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0009~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Proximal margin|Not available",
+									"qualifier_concept_id": "9191"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-27",
+									"observation_id": "TREATMENT_0009~OMOP_Surgery_Episode_Margin_Negative_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0009~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Common bile duct margin",
+									"qualifier_concept_id": "9189"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-27",
+									"observation_id": "TREATMENT_0009~OMOP_Surgery_Episode_Margin_Unassessible_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0009~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Proximal margin",
+									"qualifier_concept_id": "4183475"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0010~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-06-23",
+									"episode_end_date": "2001-05-06",
+									"episode_number": "4188540"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0010~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Systemic therapy",
+									"procedure_date": "2000-06-23",
+									"modifier_concept_id": "0",
+									"modifier_source_value": "Treatment ongoing"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0010~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0010~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-23",
+									"observation_id": "TREATMENT_0010~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0010~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4044554",
+									"value_source_value": "Preventive"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-23",
+									"observation_id": "TREATMENT_0010~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "0",
+									"value_source_value": "Complete response",
+									"observation_event_id": "TREATMENT_0010~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "RECIST 1.1"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0010~OMOP_Radiation_Episode",
+									"episode_concept_id": "32940",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "40317890",
+									"episode_start_date": "2000-06-23"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0010~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0010~OMOP_Radiation_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0010~OMOP_Radiation_Procedure",
+									"procedure_concept_id": "40317890",
+									"procedure_source_value": "Brachytherapy (procedure)",
+									"procedure_date": "2000-06-23"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0010~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0010~OMOP_Radiation_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0010~OMOP_Radiation_Boost_Procedure",
+									"procedure_concept_id": "40482853",
+									"procedure_date": "2000-06-23",
+									"modifier_concept_id": "4188540",
+									"modifier_source_value": "No"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0010~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0010~OMOP_Radiation_Boost_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4273629",
+									"episode_start_date": "2000-10-30",
+									"episode_end_date": "2001-02-14"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0010~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4273629",
+									"procedure_source_value": "Chemotherapy",
+									"procedure_date": "2000-10-30",
+									"quantity": 6
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C1411|Paclitaxel",
+									"drug_exposure_start_date": "2000-10-30",
+									"drug_exposure_end_date": "2001-02-14",
+									"dose_unit_source_value": "ug/m2"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C1411|Paclitaxel",
+									"drug_exposure_start_date": "2000-10-30",
+									"drug_exposure_end_date": "2001-02-14",
+									"dose_unit_source_value": "ug/m2",
+									"quantity": 34.4
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4061650",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0010~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4061650",
+									"procedure_source_value": "Hormone therapy",
+									"procedure_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|6446|Fluoxymesterone",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"dose_unit_source_value": "mg",
+									"quantity": 93.2
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|6446|Fluoxymesterone",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"dose_unit_source_value": "mg",
+									"quantity": 29.5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0010~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							}
+						]
+					}
+				]
+			}
+		},
+		{
+			"dataset": {
+				"id": "SITE_PM2C~SYNTH_02",
+				"linked_records": [
+					{
+						"person": {
+						
+								"person_source_value": "SITE_PM2C~SYNTH_02~DONOR_0006",
+								"gender_concept_id": "8532",
+								"gender_source_value": "Female",
+								"year_of_birth": "1950",
+								"month_of_birth": "4",
+								"day_of_birth": "10",
+								"race_concept_id": "4255047",
+								"ethnicity_concept_id": "4255047"
+							
+						},
+						"linked_records": [
+							{
+								"death": {
+									"death_type_concept_id": "32879",
+									"death_date": "2032-10-16",
+									"cause_concept_id": "45884396",
+									"cause_source_value": "Not available"
+								}
+							},
+							{
+								"condition_occurrence": {
+									"condition_type_concept_id": "32879",
+									"condition_occurrence_id": "DIAG_0006~OMOP_Primary_Dx_Condition",
+									"condition_concept_id": "0",
+									"condition_source_value": "C36",
+									"condition_start_date": "2000-01-01",
+									"condition_status_concept_id": "32902"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "DIAG_0006~OMOP_Primary_Dx_Episode",
+									"episode_concept_id": "32528",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_number": "1",
+									"episode_start_date": "2000-01-01",
+									"episode_end_date": "2000-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0006~OMOP_Primary_Dx_Episode",
+									"event_id": "DIAG_0006~OMOP_Primary_Dx_Condition",
+									"episode_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0006~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0006~OMOP_Primary_Dx_Initial_Diagnosis_Measurement",
+									"measurement_concept_id": "734306"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-01",
+									"observation_id": "DIAG_0006~OMOP_Primary_Dx_Site_Observation",
+									"observation_concept_id": "3011717",
+									"value_as_concept_id": "44497844",
+									"value_source_value": "Breast",
+									"observation_event_id": "DIAG_0006~OMOP_Primary_Dx_Condition",
+									"obs_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0006~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0006~OMOP_Clinical_Stage_Measurement",
+									"measurement_concept_id": "1244100",
+									"measurement_source_value": "SEER staging system",
+									"value_as_concept_id": "45880980",
+									"value_source_value": "Stage I"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0006~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0006~OMOP_Pathological_Stage_Measurement",
+									"measurement_concept_id": "1242682",
+									"measurement_source_value": "International ...",
+									"value_as_concept_id": "0",
+									"value_source_value": "In situ"
+								}
+							},
+							{
+								"specimen": {
+									"specimen_type_concept_id": "32879",
+									"specimen_id": "SPECIMEN_0006~OMOP_Specimen",
+									"specimen_concept_id": "4002890",
+									"specimen_date": "2000-01-27",
+									"anatomic_site_concept_id": "44498214",
+									"anatomic_site_source_value": "C41.8"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-27",
+									"observation_id": "SPECIMEN_0006~OMOP_Specimen_Tumour_Morphology_Observation",
+									"observation_concept_id": "36716952",
+									"observation_event_id": "SPECIMEN_0006~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "44499290",
+									"value_source_value": "9663/3"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-27",
+									"observation_id": "SPECIMEN_0006~OMOP_Specimen_Tumour_Grade_Observation",
+									"observation_concept_id": "4160340",
+									"observation_event_id": "SPECIMEN_0006~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "40459832",
+									"value_source_value": "Grade I"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-27",
+									"observation_id": "SPECIMEN_0006~OMOP_Specimen_Laterality_Observation",
+									"observation_concept_id": "4298494",
+									"observation_event_id": "SPECIMEN_0006~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "45884396",
+									"value_source_value": "Not available"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-27",
+									"observation_id": "SPECIMEN_0006~OMOP_Specimen_Processing_Technique_Observation",
+									"observation_concept_id": "4154128",
+									"observation_event_id": "SPECIMEN_0006~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4338536",
+									"value_source_value": "Cryopreservation in liquid nitrogen (dead tissue)"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-27",
+									"observation_id": "SPECIMEN_0006~OMOP_Specimen_Storage_Method_Observation",
+									"observation_concept_id": "37169821",
+									"observation_event_id": "SPECIMEN_0006~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "0",
+									"value_source_value": "OCT embedded"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0006~OMOP_Primary_Dx_Episode",
+									"event_id": "SPECIMEN_0006~OMOP_Specimen",
+									"episode_event_field_concept_id": "1147049"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0012~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-03-14",
+									"episode_end_date": "2000-06-11",
+									"episode_number": "4188539"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0012~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Systemic therapy",
+									"procedure_date": "2000-03-14",
+									"modifier_concept_id": "4191710",
+									"modifier_source_value": "Treatment incomplete because patient died"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0012~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0012~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-14",
+									"observation_id": "TREATMENT_0012~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0012~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4044554",
+									"value_source_value": "Preventive"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-14",
+									"observation_id": "TREATMENT_0012~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "0",
+									"value_source_value": "Molecular relapse (after CR MRD-)",
+									"observation_event_id": "TREATMENT_0012~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "45884396",
+									"qualifier_source_value": "Not available"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0012~OMOP_Radiation_Episode",
+									"episode_concept_id": "32940",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "607996",
+									"episode_start_date": "2000-03-14"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0012~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0012~OMOP_Radiation_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0012~OMOP_Radiation_Procedure",
+									"procedure_concept_id": "607996",
+									"procedure_source_value": "Teleradiotherapy protons (procedure)",
+									"procedure_date": "2000-03-14"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0012~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0012~OMOP_Radiation_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-14",
+									"observation_id": "TREATMENT_0012~OMOP_Radiation_Episode_Radiated_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0012~OMOP_Radiation_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "WHOLE BODY - SKIN"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0012~OMOP_Radiation_Boost_Procedure",
+									"procedure_concept_id": "40482853",
+									"procedure_date": "2000-03-14",
+									"modifier_concept_id": "4188540",
+									"modifier_source_value": "No"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0012~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0012~OMOP_Radiation_Boost_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4273629",
+									"episode_start_date": "2000-06-08",
+									"episode_end_date": "2000-06-08"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0012~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4273629",
+									"procedure_source_value": "Chemotherapy",
+									"procedure_date": "2000-06-08",
+									"quantity": 10
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C1411|Paclitaxel",
+									"drug_exposure_start_date": "2000-06-08",
+									"drug_exposure_end_date": "2000-06-08",
+									"quantity": 61.7
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C1411|Paclitaxel",
+									"drug_exposure_start_date": "2000-06-08",
+									"drug_exposure_end_date": "2000-06-08"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4061650",
+									"episode_start_date": "2000-04-04",
+									"episode_end_date": "2000-05-27"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0012~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4061650",
+									"procedure_source_value": "Hormone therapy",
+									"procedure_date": "2000-04-04",
+									"quantity": 8
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|6446|Fluoxymesterone",
+									"drug_exposure_start_date": "2000-04-04",
+									"drug_exposure_end_date": "2000-05-27",
+									"dose_unit_source_value": "mg/m2",
+									"quantity": 66.8
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|6446|Fluoxymesterone",
+									"drug_exposure_start_date": "2000-04-04",
+									"drug_exposure_end_date": "2000-05-27",
+									"dose_unit_source_value": "mg/m2",
+									"quantity": 27.8
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0012~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0011~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-04-04",
+									"episode_end_date": "2001-02-28",
+									"episode_number": "4188539"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0011~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Systemic therapy|Surgery",
+									"procedure_date": "2000-04-04"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0011~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0011~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-04",
+									"observation_id": "TREATMENT_0011~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0011~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4129646",
+									"value_source_value": "Diagnostic"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-04",
+									"observation_id": "TREATMENT_0011~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36309215",
+									"value_source_value": "Physician assessed stable disease",
+									"observation_event_id": "TREATMENT_0011~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "Blazer score"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "2000-06-21",
+									"episode_end_date": "2000-06-21"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0011~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "2000-06-21",
+									"quantity": 3
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C103194|Durvalumab",
+									"drug_exposure_start_date": "2000-06-21",
+									"drug_exposure_end_date": "2000-06-21",
+									"dose_unit_source_value": "mg",
+									"quantity": 81.5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C103194|Durvalumab",
+									"drug_exposure_start_date": "2000-06-21",
+									"drug_exposure_end_date": "2000-06-21",
+									"dose_unit_source_value": "mg",
+									"quantity": 38.0
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "2000-04-30",
+									"episode_end_date": "2000-07-09"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0011~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "2000-04-30",
+									"quantity": 10
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C68814|Nivolumab",
+									"drug_exposure_start_date": "2000-04-30",
+									"drug_exposure_end_date": "2000-07-09",
+									"dose_unit_source_value": "IU/m2",
+									"quantity": 70.4
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C68814|Nivolumab",
+									"drug_exposure_start_date": "2000-04-30",
+									"drug_exposure_end_date": "2000-07-09",
+									"dose_unit_source_value": "IU/m2",
+									"quantity": 29.1
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0011~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0011~OMOP_Surgery_Episode",
+									"episode_concept_id": "32939",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-04-04"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0011~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0011~OMOP_Surgery_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0011~OMOP_Surgery_Procedure",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "NCIt|C15281|Total Mastectomy",
+									"procedure_date": "2000-04-04"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0011~OMOP_Surgery_Episode",
+									"event_id": "TREATMENT_0011~OMOP_Surgery_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-04-04",
+									"measurement_id": "TREATMENT_0011~OMOP_Surgery_Episode_Tumour_Length_Measurement",
+									"measurement_concept_id": "4156562",
+									"measurement_event_id": "TREATMENT_0011~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 2.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-04-04",
+									"measurement_id": "TREATMENT_0011~OMOP_Surgery_Episode_Tumour_Width_Measurement",
+									"measurement_concept_id": "4156563",
+									"measurement_event_id": "TREATMENT_0011~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 7.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-04-04",
+									"measurement_id": "TREATMENT_0011~OMOP_Surgery_Episode_Greatest_Tumour_Dimension_Measurement",
+									"measurement_concept_id": "4154259",
+									"measurement_event_id": "TREATMENT_0011~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 10.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-04",
+									"observation_id": "TREATMENT_0011~OMOP_Surgery_Episode_Surgery_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0011~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "C39.8"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-04",
+									"observation_id": "TREATMENT_0011~OMOP_Surgery_Episode_Surgery_Specimen_Source_Observation",
+									"observation_concept_id": "45773156",
+									"observation_event_id": "TREATMENT_0011~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4312326",
+									"value_source_value": "Primary"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-04",
+									"observation_id": "TREATMENT_0011~OMOP_Surgery_Episode_Residual_Tumour_Classification_Observation",
+									"observation_concept_id": "4077124",
+									"observation_event_id": "TREATMENT_0011~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "36311187",
+									"value_source_value": "R1"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-04",
+									"observation_id": "TREATMENT_0011~OMOP_Surgery_Episode_Lymphovascular_Invasion_Observation",
+									"observation_concept_id": "1074673",
+									"observation_event_id": "TREATMENT_0011~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4181412",
+									"value_source_value": "Present"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-04",
+									"observation_id": "TREATMENT_0011~OMOP_Surgery_Episode_Perineural_Invasion_Observation",
+									"observation_concept_id": "4161179",
+									"observation_event_id": "TREATMENT_0011~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4181412",
+									"value_source_value": "Present"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-04",
+									"observation_id": "TREATMENT_0011~OMOP_Surgery_Episode_Margin_Positive_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0011~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Distal margin|Common bile duct margin",
+									"qualifier_concept_id": "9191"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-04",
+									"observation_id": "TREATMENT_0011~OMOP_Surgery_Episode_Margin_Negative_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0011~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Circumferential resection margin",
+									"qualifier_concept_id": "9189"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-04",
+									"observation_id": "TREATMENT_0011~OMOP_Surgery_Episode_Margin_Unassessible_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0011~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Proximal margin",
+									"qualifier_concept_id": "4183475"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1955-01-14",
+									"measurement_event_id": "TREATMENT_0011~OMOP_Treatment_Episode",
+									"meas_event_field_concept_id": "798885",
+									"measurement_id": "DONOR_0006 + $.donors[3].biomarkers[0]~OMOP_CA125_Biomarker_Measurement",
+									"measurement_concept_id": "4197913",
+									"value_as_number": 52,
+									"unit_concept_id": "4118305"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1955-01-14",
+									"measurement_event_id": "TREATMENT_0011~OMOP_Treatment_Episode",
+									"meas_event_field_concept_id": "798885",
+									"measurement_id": "DONOR_0006 + $.donors[3].biomarkers[0]~OMOP_CEA_Biomarker_Measurement",
+									"measurement_concept_id": "4244721",
+									"value_as_number": 76,
+									"unit_concept_id": "4120724"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1955-01-14",
+									"measurement_event_id": "TREATMENT_0011~OMOP_Treatment_Episode",
+									"meas_event_field_concept_id": "798885",
+									"measurement_id": "DONOR_0006 + $.donors[3].biomarkers[0]~OMOP_Estrogen_Receptor_Biomarker_Measurement",
+									"measurement_concept_id": "4307360",
+									"value_as_concept_id": "9189",
+									"unit_concept_id": "4041099"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1955-01-14",
+									"measurement_event_id": "TREATMENT_0011~OMOP_Treatment_Episode",
+									"meas_event_field_concept_id": "798885",
+									"measurement_id": "DONOR_0006 + $.donors[3].biomarkers[0]~OMOP_HER2_ISH_Status_Biomarker_Measurement",
+									"measurement_concept_id": "35918706",
+									"value_as_concept_id": "45884396"
+								}
+							}
+						]
+					},
+					{
+						"person": {
+							
+								"person_source_value": "SITE_PM2C~SYNTH_02~DONOR_0007",
+								"gender_concept_id": "4255047",
+								"year_of_birth": "1800",
+								"month_of_birth": "1",
+								"day_of_birth": "1",
+								"race_concept_id": "4255047",
+								"ethnicity_concept_id": "4255047"
+							
+						},
+						"linked_records": [
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "DONOR_0007~OMOP_Gender_Identity_Observation",
+									"observation_concept_id": "37171290",
+									"value_as_concept_id": "765761",
+									"value_source_value": "Woman"
+								}
+							},
+							{
+								"death": {
+									"death_type_concept_id": "32879",
+									"death_date": "1800-01-01"
+								}
+							},
+							{
+								"condition_occurrence": {
+									"condition_type_concept_id": "32879",
+									"condition_occurrence_id": "DIAG_0007~OMOP_Primary_Dx_Condition",
+									"condition_concept_id": "0",
+									"condition_source_value": "C87",
+									"condition_start_date": "1800-01-01",
+									"condition_status_concept_id": "32902"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "DIAG_0007~OMOP_Primary_Dx_Episode",
+									"episode_concept_id": "32528",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_number": "1",
+									"episode_start_date": "2000-01-01",
+									"episode_end_date": "2000-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0007~OMOP_Primary_Dx_Episode",
+									"event_id": "DIAG_0007~OMOP_Primary_Dx_Condition",
+									"episode_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0007~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0007~OMOP_Primary_Dx_Initial_Diagnosis_Measurement",
+									"measurement_concept_id": "734306",
+									"value_as_concept_id": "4190929",
+									"value_source_value": "Specific tumour markers"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0007~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0007~OMOP_Primary_Dx_Laterality_Measurement",
+									"measurement_concept_id": "35918306",
+									"value_as_concept_id": "36770058",
+									"value_source_value": "Right"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-01",
+									"observation_id": "DIAG_0007~OMOP_Primary_Dx_Site_Observation",
+									"observation_concept_id": "3011717",
+									"value_as_concept_id": "44498181",
+									"value_source_value": "Bronchus and lung",
+									"observation_event_id": "DIAG_0007~OMOP_Primary_Dx_Condition",
+									"obs_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0007~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0007~OMOP_Clinical_Stage_Measurement",
+									"measurement_concept_id": "607102",
+									"measurement_source_value": "Rai staging system",
+									"value_as_concept_id": "45880109",
+									"value_source_value": "Stage IV"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0007~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0007~OMOP_Pathological_Stage_Measurement",
+									"measurement_concept_id": "4112450",
+									"measurement_source_value": "St Jude staging system",
+									"value_as_concept_id": "0",
+									"value_source_value": "Stage III"
+								}
+							},
+							{
+								"specimen": {
+									"specimen_type_concept_id": "32879",
+									"specimen_id": "SPECIMEN_0007~OMOP_Specimen",
+									"specimen_concept_id": "4002890",
+									"specimen_date": "2000-03-15",
+									"anatomic_site_concept_id": "44498163",
+									"anatomic_site_source_value": "C30.0"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-15",
+									"observation_id": "SPECIMEN_0007~OMOP_Specimen_Tumour_Morphology_Observation",
+									"observation_concept_id": "36716952",
+									"observation_event_id": "SPECIMEN_0007~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "0",
+									"value_source_value": "9154/3"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-15",
+									"observation_id": "SPECIMEN_0007~OMOP_Specimen_Tumour_Grade_Observation",
+									"observation_concept_id": "4160340",
+									"observation_event_id": "SPECIMEN_0007~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "40459835",
+									"value_source_value": "Grade IV",
+									"qualifier_concept_id": "4161055",
+									"qualifier_source_value": "Nuclear grading system for DCIS"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-15",
+									"observation_id": "SPECIMEN_0007~OMOP_Specimen_Processing_Technique_Observation",
+									"observation_concept_id": "4154128",
+									"observation_event_id": "SPECIMEN_0007~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "40480027",
+									"value_source_value": "Formalin fixed - buffered"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-15",
+									"observation_id": "SPECIMEN_0007~OMOP_Specimen_Storage_Method_Observation",
+									"observation_concept_id": "37169821",
+									"observation_event_id": "SPECIMEN_0007~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "0",
+									"value_source_value": "Paraffin block"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0007~OMOP_Primary_Dx_Episode",
+									"event_id": "SPECIMEN_0007~OMOP_Specimen",
+									"episode_event_field_concept_id": "1147049"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0013~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-04-24",
+									"episode_end_date": "2001-05-10",
+									"episode_number": "4188539"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0013~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Surgery|Systemic therapy",
+									"procedure_date": "2000-04-24",
+									"modifier_concept_id": "4191710",
+									"modifier_source_value": "Treatment incomplete because patient died"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0013~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0013~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-24",
+									"observation_id": "TREATMENT_0013~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0013~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4161275",
+									"value_source_value": "Supportive"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-24",
+									"observation_id": "TREATMENT_0013~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "0",
+									"value_source_value": "Hematologic relapse (after CR MRD-, CR, CRi)",
+									"observation_event_id": "TREATMENT_0013~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "iRECIST"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4061650",
+									"episode_start_date": "2000-09-23",
+									"episode_end_date": "2001-03-05"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0013~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4061650",
+									"procedure_source_value": "Hormone therapy",
+									"procedure_date": "2000-09-23",
+									"quantity": 7
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "1525866",
+									"drug_source_value": "RxNorm|3390|Diethylstilbestrol",
+									"drug_exposure_start_date": "2000-09-23",
+									"drug_exposure_end_date": "2001-03-05",
+									"dose_unit_source_value": "ug/m2",
+									"quantity": 61.9
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "1525866",
+									"drug_source_value": "RxNorm|3390|Diethylstilbestrol",
+									"drug_exposure_start_date": "2000-09-23",
+									"drug_exposure_end_date": "2001-03-05",
+									"dose_unit_source_value": "ug/m2",
+									"quantity": 31.4
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4273629",
+									"episode_start_date": "2001-01-11",
+									"episode_end_date": "2001-04-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0013~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4273629",
+									"procedure_source_value": "Chemotherapy",
+									"procedure_date": "2001-01-11",
+									"quantity": 6
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|126941|Methotrexate",
+									"drug_exposure_start_date": "2001-01-11",
+									"drug_exposure_end_date": "2001-04-01",
+									"dose_unit_source_value": "mg/m2"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|126941|Methotrexate",
+									"drug_exposure_start_date": "2001-01-11",
+									"drug_exposure_end_date": "2001-04-01",
+									"dose_unit_source_value": "mg/m2",
+									"quantity": 43.0
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0013~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0013~OMOP_Surgery_Episode",
+									"episode_concept_id": "32939",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4096783",
+									"episode_start_date": "2000-04-24"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0013~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0013~OMOP_Surgery_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0013~OMOP_Surgery_Procedure",
+									"procedure_concept_id": "4096783",
+									"procedure_source_value": "SNOMED|26294005|Radical prostatectomy",
+									"procedure_date": "2000-04-24"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0013~OMOP_Surgery_Episode",
+									"event_id": "TREATMENT_0013~OMOP_Surgery_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-04-24",
+									"measurement_id": "TREATMENT_0013~OMOP_Surgery_Episode_Tumour_Length_Measurement",
+									"measurement_concept_id": "4156562",
+									"measurement_event_id": "TREATMENT_0013~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 9.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-04-24",
+									"measurement_id": "TREATMENT_0013~OMOP_Surgery_Episode_Tumour_Width_Measurement",
+									"measurement_concept_id": "4156563",
+									"measurement_event_id": "TREATMENT_0013~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 10.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-04-24",
+									"measurement_id": "TREATMENT_0013~OMOP_Surgery_Episode_Greatest_Tumour_Dimension_Measurement",
+									"measurement_concept_id": "4154259",
+									"measurement_event_id": "TREATMENT_0013~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 9.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-24",
+									"observation_id": "TREATMENT_0013~OMOP_Surgery_Episode_Surgery_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0013~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "C57.3"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-24",
+									"observation_id": "TREATMENT_0013~OMOP_Surgery_Episode_Surgery_Tumour_Focality_Observation",
+									"observation_concept_id": "4244984",
+									"observation_event_id": "TREATMENT_0013~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "45884396",
+									"value_source_value": "Not available"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-24",
+									"observation_id": "TREATMENT_0013~OMOP_Surgery_Episode_Surgery_Specimen_Source_Observation",
+									"observation_concept_id": "45773156",
+									"observation_event_id": "TREATMENT_0013~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4097297",
+									"value_source_value": "Local recurrence"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-24",
+									"observation_id": "TREATMENT_0013~OMOP_Surgery_Episode_Residual_Tumour_Classification_Observation",
+									"observation_concept_id": "4077124",
+									"observation_event_id": "TREATMENT_0013~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "36308125",
+									"value_source_value": "R2"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-24",
+									"observation_id": "TREATMENT_0013~OMOP_Surgery_Episode_Lymphovascular_Invasion_Observation",
+									"observation_concept_id": "1074673",
+									"observation_event_id": "TREATMENT_0013~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4294167",
+									"value_source_value": "Both lymphatic and small..."
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-24",
+									"observation_id": "TREATMENT_0013~OMOP_Surgery_Episode_Perineural_Invasion_Observation",
+									"observation_concept_id": "4161179",
+									"observation_event_id": "TREATMENT_0013~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4181412",
+									"value_source_value": "Present"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-24",
+									"observation_id": "TREATMENT_0013~OMOP_Surgery_Episode_Margin_Positive_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0013~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Circumferential resection",
+									"qualifier_concept_id": "9191"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-24",
+									"observation_id": "TREATMENT_0013~OMOP_Surgery_Episode_Margin_Negative_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0013~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Not applicable",
+									"qualifier_concept_id": "9189"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-24",
+									"observation_id": "TREATMENT_0013~OMOP_Surgery_Episode_Margin_Unassessible_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0013~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Not applicable",
+									"qualifier_concept_id": "4183475"
+								}
+							},
+							{
+								"visit_occurrence": {
+									"visit_type_concept_id": "32879",
+									"visit_occurrence_id": "FOLLOW_UP_0005~OMOP_Follow_Up_Visit_Occurrence",
+									"visit_concept_id": "9202",
+									"visit_start_date": "2001-11-19",
+									"visit_end_date": "2001-11-19"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2001-11-19",
+									"observation_id": "FOLLOW_UP_0005~OMOP_Follow_Up_Disease_Status_Observation",
+									"observation_concept_id": "4203711",
+									"observation_event_id": "FOLLOW_UP_0005~OMOP_Follow_Up_Visit_Occurrence",
+									"obs_event_field_concept_id": "1147070",
+									"value_as_concept_id": "36309727",
+									"value_source_value": "Complete remission"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "FOLLOW_UP_0005~OMOP_Follow_Up_Relapse_Type_Observation",
+									"observation_concept_id": "4117444",
+									"observation_event_id": "FOLLOW_UP_0005~OMOP_Follow_Up_Visit_Occurrence",
+									"obs_event_field_concept_id": "1147070",
+									"value_as_concept_id": "1620371",
+									"value_source_value": "Distant recurrence/metastasis"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0014~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "1800-01-01",
+									"episode_number": "4188540"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0014~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Other|Stem cell transplant...",
+									"procedure_date": "1800-01-01",
+									"modifier_concept_id": "9177",
+									"modifier_source_value": "Other"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0014~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0014~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "TREATMENT_0014~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0014~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4234571",
+									"value_source_value": "Screening"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "TREATMENT_0014~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36309215",
+									"value_source_value": "Immune stable disease (iSD)",
+									"observation_event_id": "TREATMENT_0014~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "RECIST 1.1"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0014~OMOP_Radiation_Episode",
+									"episode_concept_id": "32940",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4255047",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0014~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0014~OMOP_Radiation_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0014~OMOP_Radiation_Procedure",
+									"procedure_concept_id": "4255047",
+									"procedure_date": "1800-01-01",
+									"modifier_concept_id": "4130085",
+									"modifier_source_value": "External"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0014~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0014~OMOP_Radiation_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "TREATMENT_0014~OMOP_Radiation_Episode_Radiated_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0014~OMOP_Radiation_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4028235",
+									"value_source_value": "LOWER BODY"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0014~OMOP_Radiation_Boost_Procedure",
+									"procedure_concept_id": "40482853",
+									"procedure_date": "1800-01-01",
+									"modifier_concept_id": "4188540",
+									"modifier_source_value": "No"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0014~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0014~OMOP_Radiation_Boost_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0014~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "1800-01-01",
+									"quantity": 5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C2654|Ipilimumab",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"quantity": 69.2
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C2654|Ipilimumab",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"quantity": 28.0
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4061650",
+									"episode_start_date": "1800-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0014~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4061650",
+									"procedure_source_value": "Hormone therapy",
+									"procedure_date": "1800-01-01",
+									"quantity": 9
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "19033280",
+									"drug_source_value": "RxNorm|1825|Buserelin",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"dose_unit_source_value": "mg",
+									"quantity": 81.6
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "19033280",
+									"drug_source_value": "RxNorm|1825|Buserelin",
+									"drug_exposure_start_date": "1800-01-01",
+									"drug_exposure_end_date": "1800-01-01",
+									"dose_unit_source_value": "mg",
+									"quantity": 42.7
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0014~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1996-05-28",
+									"measurement_event_id": "FOLLOW_UP_0005~OMOP_Follow_Up_Visit_Occurrence",
+									"meas_event_field_concept_id": "1147070",
+									"measurement_id": "DONOR_0007 + $.donors[4].biomarkers[0]~OMOP_PSA_Biomarker_Measurement",
+									"measurement_concept_id": "4272032",
+									"value_as_number": 95,
+									"unit_concept_id": "4120724"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1996-05-28",
+									"measurement_event_id": "FOLLOW_UP_0005~OMOP_Follow_Up_Visit_Occurrence",
+									"meas_event_field_concept_id": "1147070",
+									"measurement_id": "DONOR_0007 + $.donors[4].biomarkers[0]~OMOP_CA125_Biomarker_Measurement",
+									"measurement_concept_id": "4197913",
+									"value_as_number": 34,
+									"unit_concept_id": "4118305"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1996-05-28",
+									"measurement_event_id": "FOLLOW_UP_0005~OMOP_Follow_Up_Visit_Occurrence",
+									"meas_event_field_concept_id": "1147070",
+									"measurement_id": "DONOR_0007 + $.donors[4].biomarkers[0]~OMOP_CEA_Biomarker_Measurement",
+									"measurement_concept_id": "4244721",
+									"value_as_number": 83,
+									"unit_concept_id": "4120724"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1996-05-28",
+									"measurement_event_id": "FOLLOW_UP_0005~OMOP_Follow_Up_Visit_Occurrence",
+									"meas_event_field_concept_id": "1147070",
+									"measurement_id": "DONOR_0007 + $.donors[4].biomarkers[0]~OMOP_HER2_ISH_Status_Biomarker_Measurement",
+									"measurement_concept_id": "35918706",
+									"value_as_concept_id": "9191"
+								}
+							}
+						]
+					},
+					{
+						"person": {
+							
+								"person_source_value": "SITE_PM2C~SYNTH_02~DONOR_0008",
+								"gender_concept_id": "8532",
+								"gender_source_value": "Female",
+								"year_of_birth": "1947",
+								"month_of_birth": "4",
+								"day_of_birth": "4",
+								"race_concept_id": "4255047",
+								"ethnicity_concept_id": "4255047"
+							
+						},
+						"linked_records": [
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "DONOR_0008~OMOP_Gender_Identity_Observation",
+									"observation_concept_id": "37171290",
+									"value_as_concept_id": "37171288",
+									"value_source_value": "Non-binary"
+								}
+							},
+							{
+								"death": {
+									"death_type_concept_id": "32879",
+									"death_date": "2039-05-27",
+									"cause_concept_id": "443392",
+									"cause_source_value": "Died of cancer"
+								}
+							},
+							{
+								"condition_occurrence": {
+									"condition_type_concept_id": "32879",
+									"condition_occurrence_id": "DIAG_0008~OMOP_Primary_Dx_Condition",
+									"condition_concept_id": "45755333",
+									"condition_source_value": "D07",
+									"condition_start_date": "2000-01-01",
+									"condition_status_concept_id": "32902"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "DIAG_0008~OMOP_Primary_Dx_Episode",
+									"episode_concept_id": "32528",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "45755333",
+									"episode_number": "1",
+									"episode_start_date": "2000-01-01",
+									"episode_end_date": "2000-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0008~OMOP_Primary_Dx_Episode",
+									"event_id": "DIAG_0008~OMOP_Primary_Dx_Condition",
+									"episode_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0008~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0008~OMOP_Primary_Dx_Initial_Diagnosis_Measurement",
+									"measurement_concept_id": "734306",
+									"value_as_concept_id": "439401",
+									"value_source_value": "Cytology"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-01",
+									"observation_id": "DIAG_0008~OMOP_Primary_Dx_Site_Observation",
+									"observation_concept_id": "3011717",
+									"value_as_concept_id": "44498119",
+									"value_source_value": "Colon",
+									"observation_event_id": "DIAG_0008~OMOP_Primary_Dx_Condition",
+									"obs_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0008~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0008~OMOP_Clinical_Stage_Measurement",
+									"measurement_concept_id": "4255047",
+									"value_as_concept_id": "46237084",
+									"value_source_value": "Stage IIEB"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0008~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0008~OMOP_Pathological_Stage_Measurement",
+									"measurement_concept_id": "4110410",
+									"measurement_source_value": "International Neuroblastoma....",
+									"value_as_concept_id": "0",
+									"value_source_value": "Stage IVBES"
+								}
+							},
+							{
+								"specimen": {
+									"specimen_type_concept_id": "32879",
+									"specimen_id": "SPECIMEN_0008~OMOP_Specimen",
+									"specimen_concept_id": "4002890",
+									"specimen_date": "1800-01-01",
+									"anatomic_site_concept_id": "44498186",
+									"anatomic_site_source_value": "C34.8"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "SPECIMEN_0008~OMOP_Specimen_Tumour_Grade_Observation",
+									"observation_concept_id": "4160340",
+									"observation_event_id": "SPECIMEN_0008~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "37164078",
+									"value_source_value": "G4",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "Grading system for GISTs"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "SPECIMEN_0008~OMOP_Specimen_Processing_Technique_Observation",
+									"observation_concept_id": "4154128",
+									"observation_event_id": "SPECIMEN_0008~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "40480027",
+									"value_source_value": "Formalin fixed & paraffin embedded"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0008~OMOP_Primary_Dx_Episode",
+									"event_id": "SPECIMEN_0008~OMOP_Specimen",
+									"episode_event_field_concept_id": "1147049"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0015~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-06-02",
+									"episode_end_date": "2001-02-24",
+									"episode_number": "4188540"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0015~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Radiation therapy|Photodynamic...",
+									"procedure_date": "2000-06-02",
+									"modifier_concept_id": "4191710",
+									"modifier_source_value": "Patient choice (stopped or interrupted treatment)"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0015~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0015~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-02",
+									"observation_id": "TREATMENT_0015~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36308003",
+									"value_source_value": "Progressive disease",
+									"observation_event_id": "TREATMENT_0015~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "2000-12-28",
+									"episode_end_date": "2001-02-12"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0015~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "2000-12-28"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C106432|Pembrolizumab",
+									"drug_exposure_start_date": "2000-12-28",
+									"drug_exposure_end_date": "2001-02-12",
+									"quantity": 65.2
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C106432|Pembrolizumab",
+									"drug_exposure_start_date": "2000-12-28",
+									"drug_exposure_end_date": "2001-02-12",
+									"quantity": 38.8
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4273629",
+									"episode_start_date": "2000-12-15",
+									"episode_end_date": "2001-01-05"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0015~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4273629",
+									"procedure_source_value": "Chemotherapy",
+									"procedure_date": "2000-12-15",
+									"quantity": 8
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C1094|Fludarabine",
+									"drug_exposure_start_date": "2000-12-15",
+									"drug_exposure_end_date": "2001-01-05",
+									"dose_unit_source_value": "ug/m2",
+									"quantity": 77.9
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C1094|Fludarabine",
+									"drug_exposure_start_date": "2000-12-15",
+									"drug_exposure_end_date": "2001-01-05",
+									"dose_unit_source_value": "ug/m2",
+									"quantity": 27.1
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0015~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0015~OMOP_Surgery_Episode",
+									"episode_concept_id": "32939",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4131021",
+									"episode_start_date": "2000-06-02"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0015~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0015~OMOP_Surgery_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0015~OMOP_Surgery_Procedure",
+									"procedure_concept_id": "4131021",
+									"procedure_source_value": "SNOMED|26452005|Total gastrectomy",
+									"procedure_date": "2000-06-02"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0015~OMOP_Surgery_Episode",
+									"event_id": "TREATMENT_0015~OMOP_Surgery_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-06-02",
+									"measurement_id": "TREATMENT_0015~OMOP_Surgery_Episode_Tumour_Length_Measurement",
+									"measurement_concept_id": "4156562",
+									"measurement_event_id": "TREATMENT_0015~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 7.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-06-02",
+									"measurement_id": "TREATMENT_0015~OMOP_Surgery_Episode_Tumour_Width_Measurement",
+									"measurement_concept_id": "4156563",
+									"measurement_event_id": "TREATMENT_0015~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 10.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-06-02",
+									"measurement_id": "TREATMENT_0015~OMOP_Surgery_Episode_Greatest_Tumour_Dimension_Measurement",
+									"measurement_concept_id": "4154259",
+									"measurement_event_id": "TREATMENT_0015~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 2.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-02",
+									"observation_id": "TREATMENT_0015~OMOP_Surgery_Episode_Surgery_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0015~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "C71.7"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-02",
+									"observation_id": "TREATMENT_0015~OMOP_Surgery_Episode_Residual_Tumour_Classification_Observation",
+									"observation_concept_id": "4077124",
+									"observation_event_id": "TREATMENT_0015~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "45884396",
+									"value_source_value": "Not available"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-02",
+									"observation_id": "TREATMENT_0015~OMOP_Surgery_Episode_Lymphovascular_Invasion_Observation",
+									"observation_concept_id": "1074673",
+									"observation_event_id": "TREATMENT_0015~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4181412",
+									"value_source_value": "Present"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-02",
+									"observation_id": "TREATMENT_0015~OMOP_Surgery_Episode_Perineural_Invasion_Observation",
+									"observation_concept_id": "4161179",
+									"observation_event_id": "TREATMENT_0015~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4132135",
+									"value_source_value": "Absent"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-02",
+									"observation_id": "TREATMENT_0015~OMOP_Surgery_Episode_Margin_Positive_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0015~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Proximal margin|Not applicable|Distal margin",
+									"qualifier_concept_id": "9191"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0016~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-03-21",
+									"episode_end_date": "2000-12-20",
+									"episode_number": "4188540"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0016~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Other|Radiation therapy|Systemic therapy",
+									"procedure_date": "2000-03-21",
+									"modifier_concept_id": "4082735",
+									"modifier_source_value": "Treatment completed as prescribed"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0016~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0016~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-21",
+									"observation_id": "TREATMENT_0016~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36309215",
+									"value_source_value": "Stable disease",
+									"observation_event_id": "TREATMENT_0016~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "Response Assessment in Neuro-Oncology (RANO)"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0016~OMOP_Radiation_Episode",
+									"episode_concept_id": "32940",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-03-21"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0016~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0016~OMOP_Radiation_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0016~OMOP_Radiation_Procedure",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Radiopharmaceutical",
+									"procedure_date": "2000-03-21",
+									"modifier_concept_id": "4130085",
+									"modifier_source_value": "External"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0016~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0016~OMOP_Radiation_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-03-21",
+									"measurement_id": "TREATMENT_0016~OMOP_Radiation_Episode_Total_Dose_Given_Measurement",
+									"measurement_concept_id": "40483776",
+									"measurement_event_id": "TREATMENT_0016~OMOP_Radiation_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 30,
+									"unit_concept_id": "4037797"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-03-21",
+									"observation_id": "TREATMENT_0016~OMOP_Radiation_Episode_Radiated_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0016~OMOP_Radiation_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "35632105",
+									"value_source_value": "LEFT SUPRACLAVICULAR NODES"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0016~OMOP_Radiation_Boost_Procedure",
+									"procedure_concept_id": "40482853",
+									"procedure_date": "2000-03-21",
+									"modifier_concept_id": "4188540",
+									"modifier_source_value": "No"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0016~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0016~OMOP_Radiation_Boost_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "2000-11-01",
+									"episode_end_date": "2000-12-07"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0016~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "2000-11-01",
+									"quantity": 8
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|469690927|Atezolizumab",
+									"drug_exposure_start_date": "2000-11-01",
+									"drug_exposure_end_date": "2000-12-07",
+									"dose_unit_source_value": "mg/m2",
+									"quantity": 53.2
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|469690927|Atezolizumab",
+									"drug_exposure_start_date": "2000-11-01",
+									"drug_exposure_end_date": "2000-12-07",
+									"dose_unit_source_value": "mg/m2",
+									"quantity": 22.5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "2000-12-11",
+									"episode_end_date": "2000-12-12"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0016~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "2000-12-11"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|469691028|Pembrolizumab",
+									"drug_exposure_start_date": "2000-12-11",
+									"drug_exposure_end_date": "2000-12-12",
+									"dose_unit_source_value": "mg/kg",
+									"quantity": 72.4
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|469691028|Pembrolizumab",
+									"drug_exposure_start_date": "2000-12-11",
+									"drug_exposure_end_date": "2000-12-12",
+									"dose_unit_source_value": "mg/kg",
+									"quantity": 49.0
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0016~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "DONOR_0008 + $.donors[5].exposures[0]~OMOP_Tobacco_Smoking_Status_Observation",
+									"observation_concept_id": "43054909",
+									"value_as_concept_id": "4298794",
+									"value_source_value": "Current smoker"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "DONOR_0008 + $.donors[5].exposures[0]~OMOP_Tobacco_Type_Observation",
+									"observation_concept_id": "37172639",
+									"observation_event_id": "DONOR_0008 + $.donors[5].exposures[0]~OMOP_Tobacco_Smoking_Status_Observation",
+									"obs_event_field_concept_id": "1147165",
+									"value_as_concept_id": "0",
+									"value_source_value": "Roll-ups|Not available"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1998-01-25",
+									"measurement_id": "DONOR_0008 + $.donors[5].biomarkers[0]~OMOP_PSA_Biomarker_Measurement",
+									"measurement_concept_id": "4272032",
+									"value_as_number": 32,
+									"unit_concept_id": "4120724"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1998-01-25",
+									"measurement_id": "DONOR_0008 + $.donors[5].biomarkers[0]~OMOP_CA125_Biomarker_Measurement",
+									"measurement_concept_id": "4197913",
+									"value_as_number": 38,
+									"unit_concept_id": "4118305"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1998-01-25",
+									"measurement_id": "DONOR_0008 + $.donors[5].biomarkers[0]~OMOP_CEA_Biomarker_Measurement",
+									"measurement_concept_id": "4244721",
+									"value_as_number": 3,
+									"unit_concept_id": "4120724"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1998-01-25",
+									"measurement_id": "DONOR_0008 + $.donors[5].biomarkers[0]~OMOP_Estrogen_Receptor_Biomarker_Measurement",
+									"measurement_concept_id": "4307360",
+									"value_as_concept_id": "4294169",
+									"unit_concept_id": "4041099"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1998-01-25",
+									"measurement_id": "DONOR_0008 + $.donors[5].biomarkers[0]~OMOP_HER2_IHC_Status_Biomarker_Measurement",
+									"measurement_concept_id": "35918264",
+									"value_as_concept_id": "45884396"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "1998-01-25",
+									"measurement_id": "DONOR_0008 + $.donors[5].biomarkers[0]~OMOP_HER2_ISH_Status_Biomarker_Measurement",
+									"measurement_concept_id": "35918706",
+									"value_as_concept_id": "45884396"
+								}
+							}
+						]
+					},
+					{
+						"person": {
+							
+								"person_source_value": "SITE_PM2C~SYNTH_02~DONOR_0009",
+								"gender_concept_id": "8507",
+								"gender_source_value": "Male",
+								"year_of_birth": "1949",
+								"month_of_birth": "11",
+								"day_of_birth": "5",
+								"race_concept_id": "4255047",
+								"ethnicity_concept_id": "4255047"
+							
+						},
+						"linked_records": [
+							{
+								"death": {
+									"death_type_concept_id": "32879",
+									"death_date": "1800-01-01"
+								}
+							},
+							{
+								"condition_occurrence": {
+									"condition_type_concept_id": "32879",
+									"condition_occurrence_id": "DIAG_0009~OMOP_Primary_Dx_Condition",
+									"condition_concept_id": "45571611",
+									"condition_source_value": "D37",
+									"condition_start_date": "2000-01-01",
+									"condition_status_concept_id": "32902"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "DIAG_0009~OMOP_Primary_Dx_Episode",
+									"episode_concept_id": "32528",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "45571611",
+									"episode_number": "1",
+									"episode_start_date": "2000-01-01",
+									"episode_end_date": "2000-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0009~OMOP_Primary_Dx_Episode",
+									"event_id": "DIAG_0009~OMOP_Primary_Dx_Condition",
+									"episode_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0009~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0009~OMOP_Primary_Dx_Initial_Diagnosis_Measurement",
+									"measurement_concept_id": "734306",
+									"value_as_concept_id": "4161575",
+									"value_source_value": "Death certificate only"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0009~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0009~OMOP_Primary_Dx_Laterality_Measurement",
+									"measurement_concept_id": "35918306",
+									"value_as_concept_id": "4280221",
+									"value_source_value": "Unilateral, side not specified"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-01",
+									"observation_id": "DIAG_0009~OMOP_Primary_Dx_Site_Observation",
+									"observation_concept_id": "3011717",
+									"value_as_concept_id": "44498222",
+									"value_source_value": "Skin",
+									"observation_event_id": "DIAG_0009~OMOP_Primary_Dx_Condition",
+									"obs_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0009~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0009~OMOP_Clinical_Stage_Measurement",
+									"measurement_concept_id": "4255047",
+									"value_as_concept_id": "45876316",
+									"value_source_value": "Stage IIAES"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0009~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0009~OMOP_Pathological_Stage_Measurement",
+									"measurement_concept_id": "4115000",
+									"measurement_source_value": "Ann Arbor staging system",
+									"value_as_concept_id": "0",
+									"value_source_value": "Stage IE"
+								}
+							},
+							{
+								"specimen": {
+									"specimen_type_concept_id": "32879",
+									"specimen_id": "SPECIMEN_0009~OMOP_Specimen",
+									"specimen_concept_id": "4002890",
+									"specimen_date": "2000-01-01",
+									"anatomic_site_concept_id": "44498183",
+									"anatomic_site_source_value": "C34.1"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-01",
+									"observation_id": "SPECIMEN_0009~OMOP_Specimen_Tumour_Morphology_Observation",
+									"observation_concept_id": "36716952",
+									"observation_event_id": "SPECIMEN_0009~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "0",
+									"value_source_value": "9928/3"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-01",
+									"observation_id": "SPECIMEN_0009~OMOP_Specimen_Tumour_Grade_Observation",
+									"observation_concept_id": "4160340",
+									"observation_event_id": "SPECIMEN_0009~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4255047",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "Scarff-Bloom-Richardson grading system"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-01",
+									"observation_id": "SPECIMEN_0009~OMOP_Specimen_Laterality_Observation",
+									"observation_concept_id": "4298494",
+									"observation_event_id": "SPECIMEN_0009~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4300877",
+									"value_source_value": "Left"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-01-01",
+									"observation_id": "SPECIMEN_0009~OMOP_Specimen_Processing_Technique_Observation",
+									"observation_concept_id": "4154128",
+									"observation_event_id": "SPECIMEN_0009~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4338536",
+									"value_source_value": "Cryopreservation of live cells in liquid nitrogen"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0009~OMOP_Primary_Dx_Episode",
+									"event_id": "SPECIMEN_0009~OMOP_Specimen",
+									"episode_event_field_concept_id": "1147049"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0017~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-02-02",
+									"episode_end_date": "2000-09-10",
+									"episode_number": "4188540"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0017~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Targeted molecular therapy",
+									"procedure_date": "2000-02-02",
+									"modifier_concept_id": "45884396",
+									"modifier_source_value": "Not available"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0017~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0017~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-02",
+									"observation_id": "TREATMENT_0017~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0017~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4044554",
+									"value_source_value": "Preventive"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-02",
+									"observation_id": "TREATMENT_0017~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36309453",
+									"value_source_value": "Partial remission",
+									"observation_event_id": "TREATMENT_0017~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "45884396",
+									"qualifier_source_value": "Not available"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4273629",
+									"episode_start_date": "2000-05-02",
+									"episode_end_date": "2000-07-03"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0017~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4273629",
+									"procedure_source_value": "Chemotherapy",
+									"procedure_date": "2000-05-02",
+									"quantity": 6
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C1094|Fludarabine",
+									"drug_exposure_start_date": "2000-05-02",
+									"drug_exposure_end_date": "2000-07-03"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "NCI Thesaurus|C1094|Fludarabine",
+									"drug_exposure_start_date": "2000-05-02",
+									"drug_exposure_end_date": "2000-07-03",
+									"quantity": 30.7
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4061650",
+									"episode_start_date": "2000-05-21",
+									"episode_end_date": "2000-08-21"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0017~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4061650",
+									"procedure_source_value": "Hormone therapy",
+									"procedure_date": "2000-05-21",
+									"quantity": 9
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "19058410",
+									"drug_source_value": "RxNorm|475230|Degarelix",
+									"drug_exposure_start_date": "2000-05-21",
+									"drug_exposure_end_date": "2000-08-21",
+									"quantity": 68.1
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "19058410",
+									"drug_source_value": "RxNorm|475230|Degarelix",
+									"drug_exposure_start_date": "2000-05-21",
+									"drug_exposure_end_date": "2000-08-21",
+									"quantity": 47.0
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0017~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0017~OMOP_Surgery_Episode",
+									"episode_concept_id": "32939",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-02-02"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0017~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0017~OMOP_Surgery_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0017~OMOP_Surgery_Procedure",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "UMLS|C0085704|Exploratory laparotomy",
+									"procedure_date": "2000-02-02"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0017~OMOP_Surgery_Episode",
+									"event_id": "TREATMENT_0017~OMOP_Surgery_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-02-02",
+									"measurement_id": "TREATMENT_0017~OMOP_Surgery_Episode_Tumour_Length_Measurement",
+									"measurement_concept_id": "4156562",
+									"measurement_event_id": "TREATMENT_0017~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 10.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-02-02",
+									"measurement_id": "TREATMENT_0017~OMOP_Surgery_Episode_Tumour_Width_Measurement",
+									"measurement_concept_id": "4156563",
+									"measurement_event_id": "TREATMENT_0017~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 5.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-02-02",
+									"measurement_id": "TREATMENT_0017~OMOP_Surgery_Episode_Greatest_Tumour_Dimension_Measurement",
+									"measurement_concept_id": "4154259",
+									"measurement_event_id": "TREATMENT_0017~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 10.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-02",
+									"observation_id": "TREATMENT_0017~OMOP_Surgery_Episode_Surgery_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0017~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "C75.5"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-02",
+									"observation_id": "TREATMENT_0017~OMOP_Surgery_Episode_Surgery_Tumour_Focality_Observation",
+									"observation_concept_id": "4244984",
+									"observation_event_id": "TREATMENT_0017~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "45884396",
+									"value_source_value": "Not available"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-02",
+									"observation_id": "TREATMENT_0017~OMOP_Surgery_Episode_Surgery_Specimen_Source_Observation",
+									"observation_concept_id": "45773156",
+									"observation_event_id": "TREATMENT_0017~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4312326",
+									"value_source_value": "Primary"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-02",
+									"observation_id": "TREATMENT_0017~OMOP_Surgery_Episode_Residual_Tumour_Classification_Observation",
+									"observation_concept_id": "4077124",
+									"observation_event_id": "TREATMENT_0017~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4294169",
+									"value_source_value": "Not applicable"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-02",
+									"observation_id": "TREATMENT_0017~OMOP_Surgery_Episode_Lymphovascular_Invasion_Observation",
+									"observation_concept_id": "1074673",
+									"observation_event_id": "TREATMENT_0017~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4294167",
+									"value_source_value": "Both lymphatic and small vessel..."
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-02",
+									"observation_id": "TREATMENT_0017~OMOP_Surgery_Episode_Perineural_Invasion_Observation",
+									"observation_concept_id": "4161179",
+									"observation_event_id": "TREATMENT_0017~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "607928",
+									"value_source_value": "Cannot be assessed"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-02",
+									"observation_id": "TREATMENT_0017~OMOP_Surgery_Episode_Margin_Positive_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0017~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Common bile duct margin|Not applicable",
+									"qualifier_concept_id": "9191"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-02",
+									"observation_id": "TREATMENT_0017~OMOP_Surgery_Episode_Margin_Negative_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0017~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Not available",
+									"qualifier_concept_id": "9189"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-02",
+									"observation_id": "TREATMENT_0017~OMOP_Surgery_Episode_Margin_Unassessible_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0017~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Not available",
+									"qualifier_concept_id": "4183475"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0018~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-06-03",
+									"episode_number": "4188539"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0018~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Photodynamic therapy",
+									"procedure_date": "2000-06-03",
+									"modifier_concept_id": "4191710",
+									"modifier_source_value": "Treatment incomplete because patient died"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0018~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0018~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-03",
+									"observation_id": "TREATMENT_0018~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0018~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4234571",
+									"value_source_value": "Screening"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-03",
+									"observation_id": "TREATMENT_0018~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36309453",
+									"value_source_value": "Physician assessed partial response",
+									"observation_event_id": "TREATMENT_0018~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "iRECIST"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0018~OMOP_Radiation_Episode",
+									"episode_concept_id": "32940",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-06-03"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0018~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0018~OMOP_Radiation_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0018~OMOP_Radiation_Procedure",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Radiopharmaceutical",
+									"procedure_date": "2000-06-03",
+									"modifier_concept_id": "4127806",
+									"modifier_source_value": "Internal"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0018~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0018~OMOP_Radiation_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-06-03",
+									"measurement_id": "TREATMENT_0018~OMOP_Radiation_Episode_Total_Dose_Given_Measurement",
+									"measurement_concept_id": "40483776",
+									"measurement_event_id": "TREATMENT_0018~OMOP_Radiation_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 32,
+									"unit_concept_id": "4037797"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-06-03",
+									"observation_id": "TREATMENT_0018~OMOP_Radiation_Episode_Radiated_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0018~OMOP_Radiation_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "36695848",
+									"value_source_value": "RIGHT ORBIT"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0018~OMOP_Radiation_Boost_Procedure",
+									"procedure_concept_id": "40482853",
+									"procedure_date": "2000-06-03",
+									"modifier_concept_id": "4188540",
+									"modifier_source_value": "No"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0018~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0018~OMOP_Radiation_Boost_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "2000-07-22",
+									"episode_end_date": "2000-08-27"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0018~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "2000-07-22",
+									"quantity": 2
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|469691028|Pembrolizumab",
+									"drug_exposure_start_date": "2000-07-22",
+									"drug_exposure_end_date": "2000-08-27",
+									"dose_unit_source_value": "ug/m2",
+									"quantity": 73.5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|469691028|Pembrolizumab",
+									"drug_exposure_start_date": "2000-07-22",
+									"drug_exposure_end_date": "2000-08-27",
+									"dose_unit_source_value": "ug/m2",
+									"quantity": 36.6
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "2000-08-29",
+									"episode_end_date": "2000-10-23"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0018~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "2000-08-29",
+									"quantity": 7
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|469690927|Atezolizumab",
+									"drug_exposure_start_date": "2000-08-29",
+									"drug_exposure_end_date": "2000-10-23",
+									"quantity": 64.2
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|469690927|Atezolizumab",
+									"drug_exposure_start_date": "2000-08-29",
+									"drug_exposure_end_date": "2000-10-23",
+									"quantity": 33.5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0018~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							}
+						]
+					},
+					{
+						"person": {
+							
+								"person_source_value": "SITE_PM2C~SYNTH_02~DONOR_0010",
+								"gender_concept_id": "4255047",
+								"year_of_birth": "1957",
+								"month_of_birth": "9",
+								"day_of_birth": "25",
+								"race_concept_id": "4255047",
+								"ethnicity_concept_id": "4255047"
+							
+						},
+						"linked_records": [
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "1800-01-01",
+									"observation_id": "DONOR_0010~OMOP_Gender_Identity_Observation",
+									"observation_concept_id": "37171290",
+									"value_as_concept_id": "765761",
+									"value_source_value": "Woman"
+								}
+							},
+							{
+								"death": {
+									"death_type_concept_id": "32879",
+									"death_date": "1800-01-01"
+								}
+							},
+							{
+								"condition_occurrence": {
+									"condition_type_concept_id": "32879",
+									"condition_occurrence_id": "DIAG_0010~OMOP_Primary_Dx_Condition",
+									"condition_concept_id": "45547529",
+									"condition_source_value": "C80",
+									"condition_start_date": "2000-01-01",
+									"condition_status_concept_id": "32902"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "DIAG_0010~OMOP_Primary_Dx_Episode",
+									"episode_concept_id": "32528",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "45547529",
+									"episode_number": "1",
+									"episode_start_date": "2000-01-01",
+									"episode_end_date": "2000-01-01"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0010~OMOP_Primary_Dx_Episode",
+									"event_id": "DIAG_0010~OMOP_Primary_Dx_Condition",
+									"episode_event_field_concept_id": "1147127"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0010~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0010~OMOP_Primary_Dx_Initial_Diagnosis_Measurement",
+									"measurement_concept_id": "734306",
+									"value_as_concept_id": "4161575",
+									"value_source_value": "Death certificate only"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0010~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0010~OMOP_Primary_Dx_Laterality_Measurement",
+									"measurement_concept_id": "35918306",
+									"value_as_concept_id": "45884396",
+									"value_source_value": "Not available"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0010~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0010~OMOP_Clinical_Stage_Measurement",
+									"measurement_concept_id": "4255047",
+									"value_as_concept_id": "4127475",
+									"value_source_value": "Occult Carcinoma"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-01-01",
+									"measurement_event_id": "DIAG_0010~OMOP_Primary_Dx_Condition",
+									"meas_event_field_concept_id": "1147127",
+									"measurement_id": "DIAG_0010~OMOP_Pathological_Stage_Measurement",
+									"measurement_concept_id": "4115000",
+									"measurement_source_value": "Ann Arbor staging system",
+									"value_as_concept_id": "0",
+									"value_source_value": "Stage IV"
+								}
+							},
+							{
+								"specimen": {
+									"specimen_type_concept_id": "32879",
+									"specimen_id": "SPECIMEN_0010~OMOP_Specimen",
+									"specimen_concept_id": "4002890",
+									"specimen_date": "2000-02-22",
+									"anatomic_site_concept_id": "44497987",
+									"anatomic_site_source_value": "C76.8"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-22",
+									"observation_id": "SPECIMEN_0010~OMOP_Specimen_Tumour_Morphology_Observation",
+									"observation_concept_id": "36716952",
+									"observation_event_id": "SPECIMEN_0010~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "44498688",
+									"value_source_value": "8070/3"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-22",
+									"observation_id": "SPECIMEN_0010~OMOP_Specimen_Tumour_Grade_Observation",
+									"observation_concept_id": "4160340",
+									"observation_event_id": "SPECIMEN_0010~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "1633826",
+									"value_source_value": "Grade Group 2",
+									"qualifier_concept_id": "4079552",
+									"qualifier_source_value": "WHO grading system for CNS tumours"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-22",
+									"observation_id": "SPECIMEN_0010~OMOP_Specimen_Laterality_Observation",
+									"observation_concept_id": "4298494",
+									"observation_event_id": "SPECIMEN_0010~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "4080761",
+									"value_source_value": "Right"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-02-22",
+									"observation_id": "SPECIMEN_0010~OMOP_Specimen_Processing_Technique_Observation",
+									"observation_concept_id": "4154128",
+									"observation_event_id": "SPECIMEN_0010~OMOP_Specimen",
+									"obs_event_field_concept_id": "1147049",
+									"value_as_concept_id": "40480027",
+									"value_source_value": "Formalin fixed - unbuffered"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "DIAG_0010~OMOP_Primary_Dx_Episode",
+									"event_id": "SPECIMEN_0010~OMOP_Specimen",
+									"episode_event_field_concept_id": "1147049"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0019~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-05-27",
+									"episode_number": "4188539"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0019~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Other|Surgery|Systemic therapy",
+									"procedure_date": "2000-05-27",
+									"modifier_concept_id": "4191710",
+									"modifier_source_value": "Treatment incomplete because patient died"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0019~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0019~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-27",
+									"observation_id": "TREATMENT_0019~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0019~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "40491905",
+									"value_source_value": "Forensic"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-27",
+									"observation_id": "TREATMENT_0019~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "36309453",
+									"value_source_value": "Physician assessed partial response",
+									"observation_event_id": "TREATMENT_0019~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "Response Assessment in Neuro-Oncology (RANO)"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4061650",
+									"episode_start_date": "2000-06-27",
+									"episode_end_date": "2000-09-17"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0019~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4061650",
+									"procedure_source_value": "Hormone therapy",
+									"procedure_date": "2000-06-27"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|6446|Fluoxymesterone",
+									"drug_exposure_start_date": "2000-06-27",
+									"drug_exposure_end_date": "2000-09-17",
+									"dose_unit_source_value": "g/m2",
+									"quantity": 58.2
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|6446|Fluoxymesterone",
+									"drug_exposure_start_date": "2000-06-27",
+									"drug_exposure_end_date": "2000-09-17",
+									"dose_unit_source_value": "g/m2",
+									"quantity": 35.5
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4061650",
+									"episode_start_date": "2000-07-14",
+									"episode_end_date": "2000-10-20"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0019~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4061650",
+									"procedure_source_value": "Hormone therapy",
+									"procedure_date": "2000-07-14",
+									"quantity": 1
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|50225|Buserelin",
+									"drug_exposure_start_date": "2000-07-14",
+									"drug_exposure_end_date": "2000-10-20",
+									"dose_unit_source_value": "ug/m2",
+									"quantity": 57.7
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|50225|Buserelin",
+									"drug_exposure_start_date": "2000-07-14",
+									"drug_exposure_end_date": "2000-10-20",
+									"dose_unit_source_value": "ug/m2",
+									"quantity": 43.9
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0019~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0019~OMOP_Surgery_Episode",
+									"episode_concept_id": "32939",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4311405",
+									"episode_start_date": "2000-05-27"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0019~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0019~OMOP_Surgery_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0019~OMOP_Surgery_Procedure",
+									"procedure_concept_id": "4311405",
+									"procedure_source_value": "SNOMED|86273004|Biopsy",
+									"procedure_date": "2000-05-27"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0019~OMOP_Surgery_Episode",
+									"event_id": "TREATMENT_0019~OMOP_Surgery_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-05-27",
+									"measurement_id": "TREATMENT_0019~OMOP_Surgery_Episode_Tumour_Length_Measurement",
+									"measurement_concept_id": "4156562",
+									"measurement_event_id": "TREATMENT_0019~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 9.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-05-27",
+									"measurement_id": "TREATMENT_0019~OMOP_Surgery_Episode_Tumour_Width_Measurement",
+									"measurement_concept_id": "4156563",
+									"measurement_event_id": "TREATMENT_0019~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 5.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"measurement": {
+									"measurement_type_concept_id": "32879",
+									"measurement_date": "2000-05-27",
+									"measurement_id": "TREATMENT_0019~OMOP_Surgery_Episode_Greatest_Tumour_Dimension_Measurement",
+									"measurement_concept_id": "4154259",
+									"measurement_event_id": "TREATMENT_0019~OMOP_Surgery_Episode",
+									"meas_event_field_concept_id": "798885",
+									"value_as_number": 3.0,
+									"unit_concept_id": "4122379"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-27",
+									"observation_id": "TREATMENT_0019~OMOP_Surgery_Episode_Surgery_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0019~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "C51.0"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-27",
+									"observation_id": "TREATMENT_0019~OMOP_Surgery_Episode_Lymphovascular_Invasion_Observation",
+									"observation_concept_id": "1074673",
+									"observation_event_id": "TREATMENT_0019~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4184072",
+									"value_source_value": "Venous (large vessel) invasion only"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-27",
+									"observation_id": "TREATMENT_0019~OMOP_Surgery_Episode_Perineural_Invasion_Observation",
+									"observation_concept_id": "4161179",
+									"observation_event_id": "TREATMENT_0019~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "45884396",
+									"value_source_value": "Not available"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-27",
+									"observation_id": "TREATMENT_0019~OMOP_Surgery_Episode_Margin_Positive_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0019~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Not applicable",
+									"qualifier_concept_id": "9191"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-27",
+									"observation_id": "TREATMENT_0019~OMOP_Surgery_Episode_Margin_Negative_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0019~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Not applicable",
+									"qualifier_concept_id": "9189"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-05-27",
+									"observation_id": "TREATMENT_0019~OMOP_Surgery_Episode_Margin_Unassessible_Involvement_Observation",
+									"observation_concept_id": "4184217",
+									"observation_event_id": "TREATMENT_0019~OMOP_Surgery_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "Not available",
+									"qualifier_concept_id": "4183475"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0020~OMOP_Treatment_Episode",
+									"episode_concept_id": "32531",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-04-29",
+									"episode_end_date": "2000-07-31",
+									"episode_number": "4188540"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0020~OMOP_Treatment_Procedure_Status",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Radiation therapy|Systemic therapy",
+									"procedure_date": "2000-04-29",
+									"modifier_concept_id": "4191710",
+									"modifier_source_value": "Treatment incomplete due..."
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0020~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0020~OMOP_Treatment_Procedure_Status",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-29",
+									"observation_id": "TREATMENT_0020~OMOP_Treatment_Episode_Intent_Observation",
+									"observation_concept_id": "4133895",
+									"observation_event_id": "TREATMENT_0020~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "4044554",
+									"value_source_value": "Preventive"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-29",
+									"observation_id": "TREATMENT_0020~OMOP_Treatment_Episode_Response_Observation",
+									"observation_concept_id": "4082405",
+									"value_as_concept_id": "45884396",
+									"value_source_value": "Not available",
+									"observation_event_id": "TREATMENT_0020~OMOP_Treatment_Episode",
+									"obs_event_field_concept_id": "798885",
+									"qualifier_concept_id": "0",
+									"qualifier_source_value": "Blazer score"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0020~OMOP_Radiation_Episode",
+									"episode_concept_id": "32940",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "0",
+									"episode_start_date": "2000-04-29"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0020~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0020~OMOP_Radiation_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0020~OMOP_Radiation_Procedure",
+									"procedure_concept_id": "0",
+									"procedure_source_value": "Radiopharmaceutical",
+									"procedure_date": "2000-04-29"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0020~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0020~OMOP_Radiation_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"observation": {
+									"observation_type_concept_id": "32879",
+									"observation_date": "2000-04-29",
+									"observation_id": "TREATMENT_0020~OMOP_Radiation_Episode_Radiated_Site_Observation",
+									"observation_concept_id": "4181646",
+									"observation_event_id": "TREATMENT_0020~OMOP_Radiation_Episode",
+									"obs_event_field_concept_id": "798885",
+									"value_as_concept_id": "0",
+									"value_source_value": "INVERTED 'Y' (DOG-LEG,HOCKEY-STICK)"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0020~OMOP_Radiation_Boost_Procedure",
+									"procedure_concept_id": "40482853",
+									"procedure_date": "2000-04-29",
+									"modifier_concept_id": "4188540",
+									"modifier_source_value": "No"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0020~OMOP_Radiation_Episode",
+									"event_id": "TREATMENT_0020~OMOP_Radiation_Boost_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4061650",
+									"episode_start_date": "2000-06-18",
+									"episode_end_date": "2000-07-17"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0020~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4061650",
+									"procedure_source_value": "Hormone therapy",
+									"procedure_date": "2000-06-18",
+									"quantity": 3
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|2733526|Tamoxifen",
+									"drug_exposure_start_date": "2000-06-18",
+									"drug_exposure_end_date": "2000-07-17",
+									"dose_unit_source_value": "mg"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|2733526|Tamoxifen",
+									"drug_exposure_start_date": "2000-06-18",
+									"drug_exposure_end_date": "2000-07-17",
+									"dose_unit_source_value": "mg",
+									"quantity": 35.8
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"episode": {
+									"episode_type_concept_id": "32879",
+									"episode_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Episode",
+									"episode_concept_id": "32941",
+									"episode_source_concept_id": "0",
+									"episode_object_concept_id": "4295112",
+									"episode_start_date": "2000-06-16",
+									"episode_end_date": "2000-07-17"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0020~OMOP_Treatment_Episode",
+									"event_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Episode",
+									"episode_event_field_concept_id": "798885"
+								}
+							},
+							{
+								"procedure_occurrence": {
+									"procedure_type_concept_id": "32879",
+									"procedure_occurrence_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Procedure",
+									"procedure_concept_id": "4295112",
+									"procedure_source_value": "Immunotherapy",
+									"procedure_date": "2000-06-16",
+									"quantity": 4
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Procedure",
+									"episode_event_field_concept_id": "1147082"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"drug_type_concept_id": "32833",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|469691028|Pembrolizumab",
+									"drug_exposure_start_date": "2000-06-16",
+									"drug_exposure_end_date": "2000-07-17",
+									"dose_unit_source_value": "Not available"
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Dose_Given_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							},
+							{
+								"drug_exposure": {
+									"drug_exposure_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"drug_type_concept_id": "32838",
+									"drug_concept_id": "0",
+									"drug_source_value": "PubChem|469691028|Pembrolizumab",
+									"drug_exposure_start_date": "2000-06-16",
+									"drug_exposure_end_date": "2000-07-17",
+									"dose_unit_source_value": "Not available",
+									"quantity": 21.6
+								}
+							},
+							{
+								"episode_event": {
+									"episode_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Episode",
+									"event_id": "TREATMENT_0020~OMOP_Systemic_Therapy_Dose_Prescribed_Drug_Exposure",
+									"episode_event_field_concept_id": "1147094"
+								}
+							}
+						]
+					}
+				]
+			}
+		}
+	]
+}


### PR DESCRIPTION
This is a small sample ingestable OMOP file, that can be ingested via:

```
curl -X POST candig.docker.internal:5080/candig-api/v1/datasets/upload -H "Authorization: Bearer $TOKEN" -H "Content-Type: multipart/form-data" -F "file=@etc/tests/integration/omop-sample.json;type=application/json"
```