### PR TITLE
update with separate webhook url

### DIFF
--- a/.github/workflows/slack-notify.yaml
+++ b/.github/workflows/slack-notify.yaml
@@ -19,5 +19,5 @@ jobs:
         id: slack
         uses: slackapi/slack-github-action@v1.26.0
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.CANDIGV3_SLACK_WEBHOOK_URL }}
           


### PR DESCRIPTION
updated webhook url to be separate from the CanDIGv2 workflow