### PR TITLE
DIG-2240: Fix the fake error that happens during candig-api setup

### DIFF
--- a/lib/candig-api/candig-api_setup.sh
+++ b/lib/candig-api/candig-api_setup.sh
@@ -25,7 +25,7 @@ docker restart $ingest
 # If present, create and authorize default site admin as CanDIG authorized user:
 site_admin_token=$(python site_admin_token.py)
 if [[ $CANDIG_SITE_ADMIN_USER != "" ]]; then
-  bash $PWD/poll_until_live.sh "${CANDIG_URL}/ingest/service-info" $site_admin_token
+  bash $PWD/poll_until_live.sh "${CANDIG_URL}/candig-api/v1/authz/service-info" $site_admin_token
 
   echo ">> approving $CANDIG_SITE_ADMIN_USER as a CanDIG authorized user"
   bash $PWD/exec_with_expected.sh "curl -sX \"POST\" \"${CANDIG_URL}/candig-api/v1/authz/user/pending/request\" -H \"Authorization: Bearer ${site_admin_token}\"" "$CANDIG_SITE_ADMIN_USER"

--- a/lib/candig-api/candig-api_setup.sh
+++ b/lib/candig-api/candig-api_setup.sh
@@ -25,13 +25,7 @@ docker restart $ingest
 # If present, create and authorize default site admin as CanDIG authorized user:
 site_admin_token=$(python site_admin_token.py)
 if [[ $CANDIG_SITE_ADMIN_USER != "" ]]; then
-  bash $PWD/exec_with_expected.sh "curl -si \"${CANDIG_URL}/candig-api/v1/authz/service-info\" -H \"Authorization: Bearer ${site_admin_token}\"" "200 OK"
-  while [ $? -ne 0 ]
-  do
-    echo "..."
-      sleep 2
-      bash $PWD/exec_with_expected.sh "curl -si \"${CANDIG_URL}/candig-api/v1/authz/service-info\" -H \"Authorization: Bearer ${site_admin_token}\"" "200 OK"
-  done
+  bash $PWD/poll_until_live.sh "${CANDIG_URL}/ingest/service-info" $site_admin_token
 
   echo ">> approving $CANDIG_SITE_ADMIN_USER as a CanDIG authorized user"
   bash $PWD/exec_with_expected.sh "curl -sX \"POST\" \"${CANDIG_URL}/candig-api/v1/authz/user/pending/request\" -H \"Authorization: Bearer ${site_admin_token}\"" "$CANDIG_SITE_ADMIN_USER"

--- a/poll_until_live.sh
+++ b/poll_until_live.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# poll a url until it returns 200
+url=$1
+token=$2
+
+cmd="curl -s -w \"%{http_code}\" ${url}"
+if [[ $token != '' ]]; then
+    cmd="${cmd}  -H \"Authorization: Bearer ${token}\""
+    echo $cmd
+fi
+
+echo $cmd | bash &> .tmp_store
+grep -q "200" .tmp_store
+while [[ $? -ne 0 ]];
+do
+    sleep 2
+    echo "..."
+    echo $cmd | bash &> .tmp_store
+    grep -q "200" .tmp_store
+done
+rm .tmp_store


### PR DESCRIPTION
If you run `make recompose-candig-api`, you should not see that 500 error anymore.